### PR TITLE
BED feature

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,4 +19,7 @@
 [submodule "vendor/GenomeWorks"]
 	path = vendor/GenomeWorks
 	url = https://github.com/clara-parabricks/GenomeWorks.git
+[submodule "vendor/intervaltree"]
+	path = vendor/intervaltree
+	url = https://github.com/ekg/intervaltree.git
 	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.2)
 project(racon)
-set(racon_version 1.4.17)
+set(racon_version 1.5.0)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ if(racon_enable_cuda)
 endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/src)
+include_directories(${PROJECT_SOURCE_DIR}/vendor/intervaltree)
 
 set(racon_sources
     src/main.cpp
@@ -103,7 +104,6 @@ if (racon_build_tests)
         "${PROJECT_BINARY_DIR}/config/racon_test_config.h")
     include_directories(${PROJECT_BINARY_DIR}/config)
     include_directories(${PROJECT_SOURCE_DIR}/src)
-    include_directories(${PROJECT_SOURCE_DIR}/vendor/intervaltree)
 
     set(racon_test_sources
         test/bed_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,12 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 
 set(racon_sources
     src/main.cpp
+    src/bed.cpp
     src/logger.cpp
     src/polisher.cpp
     src/overlap.cpp
     src/sequence.cpp
+    src/util.cpp
     src/window.cpp)
 
 if(racon_enable_cuda)
@@ -101,13 +103,18 @@ if (racon_build_tests)
         "${PROJECT_BINARY_DIR}/config/racon_test_config.h")
     include_directories(${PROJECT_BINARY_DIR}/config)
     include_directories(${PROJECT_SOURCE_DIR}/src)
+    include_directories(${PROJECT_SOURCE_DIR}/vendor/intervaltree)
 
     set(racon_test_sources
+        test/bed_test.cpp
         test/racon_test.cpp
+        test/util_test.cpp
+        src/bed.cpp
         src/logger.cpp
         src/polisher.cpp
         src/overlap.cpp
         src/sequence.cpp
+        src/util.cpp
         src/window.cpp)
 
     if (racon_enable_cuda)

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'Racon',
   'cpp',
-  version : '1.4.13',
+  version : '1.5.0',
   default_options : [
     'buildtype=release',
     'warning_level=3',

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -38,12 +38,12 @@ std::string BedFile::Serialize(const BedRecord& record) {
 
 BedReader::BedReader(const std::string& in_fn)
     : file_{std::unique_ptr<std::ifstream>(new std::ifstream(in_fn))}
-    , in_{*file_.get()}
+    , in_(*file_.get())
 {
 }
 
 BedReader::BedReader(std::istream& in)
-    : in_{in}
+    : in_(in)
 {
 }
 

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -19,7 +19,7 @@ bool BedFile::Deserialize(const std::string& line, BedRecord& record) {
     char name_buff[1024];
     int64_t chrom_start = 0, chrom_end = 0;
     int32_t n = sscanf(line.c_str(), "%s %ld %ld", name_buff, &chrom_start, &chrom_end);
-    if (n < 3) {
+    if (n < 3 || chrom_end <= chrom_start) {
         throw std::runtime_error("Invalid BED line: '" + line + "'");
     }
     record = BedRecord(name_buff, chrom_start, chrom_end);

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -1,0 +1,75 @@
+/*!
+ * @file bed.cpp
+ *
+ * @brief BED reader source file
+ */
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+
+#include "bed.hpp"
+
+namespace racon {
+
+bool BedFile::Deserialize(const std::string& line, BedRecord& record) {
+    if (line.empty()) {
+        return false;
+    }
+    char name_buff[1024];
+    int64_t chrom_start = 0, chrom_end = 0;
+    int32_t n = sscanf(line.c_str(), "%s %ld %ld", name_buff, &chrom_start, &chrom_end);
+    if (n < 3) {
+        throw std::runtime_error("Invalid BED line: '" + line + "'");
+    }
+    record = BedRecord(name_buff, chrom_start, chrom_end);
+    return true;
+}
+
+void BedFile::Serialize(std::ostream& os, const BedRecord& record) {
+    os << record.chrom() << " " << record.chrom_start() << " " << record.chrom_end();
+}
+
+std::string BedFile::Serialize(const BedRecord& record) {
+    std::ostringstream oss;
+    Serialize(oss, record);
+    return oss.str();
+}
+
+BedReader::BedReader(const std::string& in_fn)
+    : file_{std::unique_ptr<std::ifstream>(new std::ifstream(in_fn))}
+    , in_{*file_.get()}
+{
+}
+
+BedReader::BedReader(std::istream& in)
+    : in_{in}
+{
+}
+
+bool BedReader::GetNext(BedRecord& record) {
+    const bool rv1 = !std::getline(in_, line_).fail();
+    if (!rv1)
+        return false;
+    const bool rv2 = BedFile::Deserialize(line_, record);
+    return rv2;
+}
+
+std::vector<BedRecord> BedReader::ReadAll(const std::string& fn)
+{
+    std::ifstream in{fn};
+    return ReadAll(in);
+}
+
+std::vector<BedRecord> BedReader::ReadAll(std::istream& in)
+{
+    std::vector<BedRecord> records;
+    BedReader reader{in};
+    BedRecord record;
+    while (reader.GetNext(record)) {
+        records.emplace_back(std::move(record));
+    }
+    return records;
+}
+
+}

--- a/src/bed.hpp
+++ b/src/bed.hpp
@@ -1,0 +1,92 @@
+/*!
+ * @file bed.hpp
+ *
+ * @brief BED file containers and parser.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace racon {
+
+class BedRecord;
+
+class BedFile {
+public:
+    static bool Deserialize(const std::string& line, BedRecord& record);
+    static void Serialize(std::ostream& os, const BedRecord& record);
+    static std::string Serialize(const BedRecord& record);
+};
+
+/*
+ * \brief BedRecord container.
+ * Note: BED records have 0-based coordinates, and the end coordinate is non-inclusive.
+*/
+class BedRecord {
+public:
+    ~BedRecord() = default;
+
+    BedRecord() = default;
+
+    BedRecord(std::string _chrom, int64_t _chrom_start, int64_t _chrom_end)
+        : chrom_(std::move(_chrom))
+        , chrom_start_(_chrom_start)
+        , chrom_end_(_chrom_end) {}
+
+    const std::string& chrom() const {
+        return chrom_;
+    }
+    int64_t chrom_start() const {
+        return chrom_start_;
+    }
+    int64_t chrom_end() const {
+        return chrom_end_;
+    }
+
+    void chrom(const std::string& val) {
+        chrom_ = val;
+    }
+    void chrom_start(int64_t val) {
+        chrom_start_ = val;
+    }
+    void chrom_end(int64_t val) {
+        chrom_end_ = val;
+    }
+
+    bool operator==(const BedRecord& rhs) const
+    {
+        return chrom_ == rhs.chrom_ && chrom_start_ == rhs.chrom_start_
+                    && chrom_end_ == rhs.chrom_end_;
+    }
+
+    std::ostream& operator<<(std::ostream& os) const {
+        BedFile::Serialize(os, *this);
+        return os;
+    }
+
+private:
+    std::string chrom_;
+    int64_t chrom_start_ = 0;
+    int64_t chrom_end_ = 0;
+};
+
+class BedReader {
+public:
+    BedReader(const std::string& in_fn);
+    BedReader(std::istream& in);
+
+    static std::vector<BedRecord> ReadAll(const std::string& fn);
+    static std::vector<BedRecord> ReadAll(std::istream& in);
+    bool GetNext(BedRecord& record);
+
+private:
+    std::unique_ptr<std::ifstream> file_;
+    std::istream& in_;
+    std::string line_;
+};
+
+}

--- a/src/bed.hpp
+++ b/src/bed.hpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <fstream>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
     std::cerr << "BED file: '" << bed_file << "'\n";
 
     auto polisher = racon::createPolisher(input_paths[0], input_paths[1],
-        input_paths[2], type == 0 ? racon::PolisherType::kC :
+        input_paths[2], bed_file, type == 0 ? racon::PolisherType::kC :
         racon::PolisherType::kF, window_length, quality_threshold,
         error_threshold, trim, match, mismatch, gap, num_threads,
         cudapoa_batches, cuda_banded_alignment, cudaaligner_batches,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <getopt.h>
 
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -31,6 +32,7 @@ static struct option options[] = {
     {"mismatch", required_argument, 0, 'x'},
     {"gap", required_argument, 0, 'g'},
     {"threads", required_argument, 0, 't'},
+    {"bed", required_argument, 0, 'B'},
     {"version", no_argument, 0, 'v'},
     {"help", no_argument, 0, 'h'},
 #ifdef CUDA_ENABLED
@@ -66,7 +68,9 @@ int main(int argc, char** argv) {
     uint32_t cudaaligner_band_width = 0;
     bool cuda_banded_alignment = false;
 
-    std::string optstring = "ufw:q:e:m:x:g:t:h";
+    std::string bed_file;
+
+    std::string optstring = "ufw:q:e:m:x:g:t:B:h";
 #ifdef CUDA_ENABLED
     optstring += "bc::";
 #endif
@@ -103,6 +107,9 @@ int main(int argc, char** argv) {
                 break;
             case 't':
                 num_threads = atoi(optarg);
+                break;
+            case 'B':
+                bed_file = std::string(optarg);
                 break;
             case 'v':
                 printf("%s\n", version);
@@ -148,6 +155,8 @@ int main(int argc, char** argv) {
         help();
         exit(1);
     }
+
+    std::cerr << "BED file: '" << bed_file << "'\n";
 
     auto polisher = racon::createPolisher(input_paths[0], input_paths[1],
         input_paths[2], type == 0 ? racon::PolisherType::kC :
@@ -209,6 +218,9 @@ void help() {
         "        -g, --gap <int>\n"
         "            default: -4\n"
         "            gap penalty (must be negative)\n"
+        "        -B, --bed <str>\n"
+        "            default: ''\n"
+        "            path to a BED file with regions to polish\n"
         "        -t, --threads <int>\n"
         "            default: 1\n"
         "            number of threads\n"

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,7 @@ racon_cpp_sources = files([
   'overlap.cpp',
   'polisher.cpp',
   'sequence.cpp',
+  'util.cpp',
   'window.cpp',
 ])
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,9 +1,10 @@
 racon_cpp_sources = files([
+  'bed.cpp',
   'logger.cpp',
   'overlap.cpp',
   'polisher.cpp',
   'sequence.cpp',
-  'window.cpp'
+  'window.cpp',
 ])
 
 racon_extra_flags = []

--- a/src/overlap.cpp
+++ b/src/overlap.cpp
@@ -8,6 +8,7 @@
 
 #include "sequence.hpp"
 #include "overlap.hpp"
+#include "util.hpp"
 #include "edlib.h"
 
 namespace racon {
@@ -112,18 +113,6 @@ Overlap::Overlap()
         t_id_(), t_begin_(), t_end_(), t_length_(), strand_(), length_(),
         error_(), cigar_(), is_valid_(true), is_transmuted_(true),
         breaking_points_(), dual_breaking_points_() {
-}
-
-template<typename T>
-bool transmuteId(const std::unordered_map<T, uint64_t>& t_to_id, const T& t,
-    uint64_t& id) {
-
-    auto it = t_to_id.find(t);
-    if (it == t_to_id.end()) {
-        return false;
-    }
-    id = it->second;
-    return true;
 }
 
 void Overlap::transmute(const std::vector<std::unique_ptr<Sequence>>& sequences,

--- a/src/overlap.cpp
+++ b/src/overlap.cpp
@@ -166,32 +166,6 @@ void Overlap::transmute(const std::vector<std::unique_ptr<Sequence>>& sequences,
 }
 
 void Overlap::find_breaking_points(const std::vector<std::unique_ptr<Sequence>>& sequences,
-    uint32_t window_length) {
-
-    if (!is_transmuted_) {
-        fprintf(stderr, "[racon::Overlap::find_breaking_points] error: "
-            "overlap is not transmuted!\n");
-        exit(1);
-    }
-
-    if (!breaking_points_.empty()) {
-        return;
-    }
-
-    if (cigar_.empty()) {
-        const char* q = !strand_ ? &(sequences[q_id_]->data()[q_begin_]) :
-            &(sequences[q_id_]->reverse_complement()[q_length_ - q_end_]);
-        const char* t = &(sequences[t_id_]->data()[t_begin_]);
-
-        align_overlaps(q, q_end_ - q_begin_, t, t_end_ - t_begin_);
-    }
-
-    find_breaking_points_from_cigar(window_length);
-
-    std::string().swap(cigar_);
-}
-
-void Overlap::find_breaking_points(const std::vector<std::unique_ptr<Sequence>>& sequences,
     std::vector<std::tuple<int64_t, int64_t, int64_t>> windows) {
 
     if (!is_transmuted_) {
@@ -240,29 +214,6 @@ void Overlap::align_overlaps(const char* q, uint32_t q_length, const char* t, ui
 
 void Overlap::find_breaking_points_from_cigar(std::vector<std::tuple<int64_t, int64_t, int64_t>> windows)
 {
-    int64_t q_start = (strand_ ? (q_length_ - q_end_) : q_begin_);
-    int64_t t_start = t_begin_;
-
-    std::vector<WindowInterval> result = generate_window_breakpoints(
-            cigar_, q_start, t_start,
-            std::move(windows));
-
-    std::swap(breaking_points_, result);
-}
-
-void Overlap::find_breaking_points_from_cigar(int64_t window_length)
-{
-    std::vector<std::tuple<int64_t, int64_t, int64_t>> windows;
-
-    // find breaking points from cigar
-    int64_t window_id = t_begin_ / window_length;
-    const int64_t start = window_id * window_length;
-    const int64_t end = t_end_;
-
-    for (int64_t i = start; i < end; i += window_length, ++window_id) {
-        windows.emplace_back(std::make_tuple(i, std::min(static_cast<int64_t>(t_length_), i + window_length), window_id));
-    }
-
     int64_t q_start = (strand_ ? (q_length_ - q_end_) : q_begin_);
     int64_t t_start = t_begin_;
 

--- a/src/overlap.cpp
+++ b/src/overlap.cpp
@@ -216,16 +216,19 @@ void Overlap::find_breaking_points_from_cigar(uint32_t window_length)
 {
     // find breaking points from cigar
     std::vector<int32_t> window_ends;
+    uint32_t w_offset = 0;
     for (uint32_t i = 0; i < t_end_; i += window_length) {
         if (i > t_begin_) {
             window_ends.emplace_back(i - 1);
+        } else {
+            ++w_offset;
         }
     }
     window_ends.emplace_back(t_end_ - 1);
 
     uint32_t w = 0;
     bool found_first_match = false;
-    std::pair<uint32_t, uint32_t> first_match = {0, 0}, last_match = {0, 0};
+    std::tuple<uint32_t, uint32_t, uint32_t> first_match = {0, 0, 0}, last_match = {0, 0, 0};
 
     int32_t q_ptr = (strand_ ? (q_length_ - q_end_) : q_begin_) - 1;
     int32_t t_ptr = t_begin_ - 1;
@@ -240,11 +243,9 @@ void Overlap::find_breaking_points_from_cigar(uint32_t window_length)
 
                 if (!found_first_match) {
                     found_first_match = true;
-                    first_match.first = t_ptr;
-                    first_match.second = q_ptr;
+                    first_match = std::make_tuple(t_ptr, q_ptr, w + w_offset);
                 }
-                last_match.first = t_ptr + 1;
-                last_match.second = q_ptr + 1;
+                last_match = std::make_tuple(t_ptr + 1, q_ptr + 1, w + w_offset);
                 if (t_ptr == window_ends[w]) {
                     if (found_first_match) {
                         breaking_points_.emplace_back(first_match);

--- a/src/overlap.hpp
+++ b/src/overlap.hpp
@@ -41,6 +41,14 @@ public:
         return t_id_;
     }
 
+    uint32_t t_begin() const {
+        return t_begin_;
+    }
+
+    uint32_t t_end() const {
+        return t_end_;
+    }
+
     uint32_t strand() const {
         return strand_;
     }

--- a/src/overlap.hpp
+++ b/src/overlap.hpp
@@ -80,9 +80,6 @@ public:
     }
 
     void find_breaking_points(const std::vector<std::unique_ptr<Sequence>>& sequences,
-        uint32_t window_length);
-
-    void find_breaking_points(const std::vector<std::unique_ptr<Sequence>>& sequences,
         std::vector<std::tuple<int64_t, int64_t, int64_t>> windows);
 
     friend bioparser::MhapParser<Overlap>;
@@ -112,7 +109,6 @@ private:
     Overlap();
     Overlap(const Overlap&) = delete;
     const Overlap& operator=(const Overlap&) = delete;
-    virtual void find_breaking_points_from_cigar(int64_t window_length);
     virtual void find_breaking_points_from_cigar(std::vector<std::tuple<int64_t, int64_t, int64_t>> windows);
     virtual void align_overlaps(const char* q, uint32_t q_len, const char* t, uint32_t t_len);
 

--- a/src/overlap.hpp
+++ b/src/overlap.hpp
@@ -6,11 +6,12 @@
 
 #pragma once
 
-#include <stdlib.h>
-#include <stdint.h>
+#include <cstdlib>
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <unordered_map>
 
@@ -73,7 +74,7 @@ public:
         return cigar_;
     }
 
-    const std::vector<std::pair<uint32_t, uint32_t>>& breaking_points() const {
+    const std::vector<std::tuple<uint32_t, uint32_t, uint32_t>>& breaking_points() const {
         return breaking_points_;
     }
 
@@ -127,7 +128,7 @@ private:
 
     bool is_valid_;
     bool is_transmuted_;
-    std::vector<std::pair<uint32_t, uint32_t>> breaking_points_;
+    std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> breaking_points_;
     std::vector<std::pair<uint32_t, uint32_t>> dual_breaking_points_;
 };
 

--- a/src/overlap.hpp
+++ b/src/overlap.hpp
@@ -89,6 +89,8 @@ public:
     friend bioparser::PafParser<Overlap>;
     friend bioparser::SamParser<Overlap>;
 
+    friend std::ostream& operator<<(::std::ostream& os, const Overlap& a);
+
 #ifdef CUDA_ENABLED
     friend class CUDABatchAligner;
 #endif
@@ -138,5 +140,14 @@ private:
 
     std::vector<WindowInterval> breaking_points_;
 };
+
+inline std::ostream& operator<<(::std::ostream& os, const Overlap& a) {
+    std::string delim(" ");
+    os << a.q_id_ << delim << a.q_begin_ << delim << a.q_end_ << delim << a.q_length_
+        << delim << (a.strand_ ? "-" : "+")
+        << delim << a.t_id_ << delim << a.t_begin_ << delim << a.t_end_ << delim << a.t_length_
+        << delim << a.cigar_ << delim << a.is_valid_ << delim << a.is_transmuted_;
+    return os;
+}
 
 }

--- a/src/overlap.hpp
+++ b/src/overlap.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "util.hpp"
 #include <cstdlib>
 #include <cstdint>
 #include <memory>
@@ -74,7 +75,7 @@ public:
         return cigar_;
     }
 
-    const std::vector<std::tuple<uint32_t, uint32_t, uint32_t>>& breaking_points() const {
+    const std::vector<WindowInterval>& breaking_points() const {
         return breaking_points_;
     }
 
@@ -106,7 +107,7 @@ private:
     Overlap();
     Overlap(const Overlap&) = delete;
     const Overlap& operator=(const Overlap&) = delete;
-    virtual void find_breaking_points_from_cigar(uint32_t window_length);
+    virtual void find_breaking_points_from_cigar(int64_t window_length);
     virtual void align_overlaps(const char* q, uint32_t q_len, const char* t, uint32_t t_len);
 
     std::string q_name_;
@@ -128,8 +129,10 @@ private:
 
     bool is_valid_;
     bool is_transmuted_;
-    std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> breaking_points_;
+    // std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> breaking_points_;
     std::vector<std::pair<uint32_t, uint32_t>> dual_breaking_points_;
+
+    std::vector<WindowInterval> breaking_points_;
 };
 
 }

--- a/src/overlap.hpp
+++ b/src/overlap.hpp
@@ -82,6 +82,9 @@ public:
     void find_breaking_points(const std::vector<std::unique_ptr<Sequence>>& sequences,
         uint32_t window_length);
 
+    void find_breaking_points(const std::vector<std::unique_ptr<Sequence>>& sequences,
+        std::vector<std::tuple<int64_t, int64_t, int64_t>> windows);
+
     friend bioparser::MhapParser<Overlap>;
     friend bioparser::PafParser<Overlap>;
     friend bioparser::SamParser<Overlap>;
@@ -108,6 +111,7 @@ private:
     Overlap(const Overlap&) = delete;
     const Overlap& operator=(const Overlap&) = delete;
     virtual void find_breaking_points_from_cigar(int64_t window_length);
+    virtual void find_breaking_points_from_cigar(std::vector<std::tuple<int64_t, int64_t, int64_t>> windows);
     virtual void align_overlaps(const char* q, uint32_t q_len, const char* t, uint32_t t_len);
 
     std::string q_name_;

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -515,7 +515,7 @@ void Polisher::create_and_populate_windows_with_bed(std::vector<std::unique_ptr<
                     &(sequences_[t_id]->quality()[win_start]), length));
 
                 target_window_intervals_[t_id].emplace_back(IntervalInt64(win_start, win_start + length - 1, win_id));
-                windows[t_id].emplace_back(win_start, win_start + length - 1, win_id);
+                windows[t_id].emplace_back(win_start, win_start + length, win_id);
             }
         }
     }

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -389,7 +389,7 @@ void Polisher::initialize() {
             uint32_t length = std::min(j + window_length_,
                 static_cast<uint32_t>(sequences_[i]->data().size())) - j;
 
-            windows_.emplace_back(createWindow(i, k, window_type,
+            windows_.emplace_back(createWindow(i, k, window_type, j,
                 &(sequences_[i]->data()[j]), length,
                 sequences_[i]->quality().empty() ? &(dummy_quality_[0]) :
                 &(sequences_[i]->quality()[j]), length));

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -461,7 +461,11 @@ void Polisher::initialize() {
         it.wait();
     }
 
+    logger_->log("[racon::Polisher::initialize] Constructing windows for BED regions.\n");
+
     create_and_populate_windows_with_bed(overlaps, targets_size, window_type);
+
+    logger_->log("[racon::Polisher::initialize] transformed data into windows");
 
 // #ifdef BED_FEATURE_TEST
 //     int32_t shift = 0;
@@ -482,8 +486,6 @@ void Polisher::initialize() {
 
 void Polisher::create_and_populate_windows_with_bed(std::vector<std::unique_ptr<Overlap>>& overlaps,
         uint64_t targets_size, WindowType window_type) {
-
-    logger_->log("Constructing windows for BED regions.\n");
 
     // The -1 marks that the target doesn't have any windows.
     id_to_first_window_id_.clear();
@@ -533,8 +535,6 @@ void Polisher::create_and_populate_windows_with_bed(std::vector<std::unique_ptr<
     find_overlap_breaking_points(overlaps, windows);
 
     assign_sequences_to_windows(overlaps, targets_size);
-
-    logger_->log("[racon::Polisher::initialize] transformed data into windows");
 }
 
 void Polisher::assign_sequences_to_windows(std::vector<std::unique_ptr<Overlap>>& overlaps, uint64_t targets_size) {

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -381,6 +381,17 @@ void Polisher::initialize() {
                 continue;
             }
 
+            // Remove overlaps in regions not specified by BED.
+            if (use_bed_) {
+                auto foundIntervals = target_trees_[overlaps[i]->t_id()].findOverlapping(
+                        static_cast<int64_t>(overlaps[i]->t_begin()),
+                        static_cast<int64_t>(overlaps[i]->t_end()) - 1);
+                if (foundIntervals.empty()) {
+                    overlaps[i].reset();
+                    continue;
+                }
+            }
+
             while (overlaps[c] == nullptr) {
                 ++c;
             }

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -21,7 +21,6 @@
 #include "thread_pool/thread_pool.hpp"
 #include "spoa/spoa.hpp"
 
-#define BED_FEATURE
 // #define BED_FEATURE_TEST
 
 namespace racon {
@@ -528,34 +527,34 @@ void Polisher::create_and_populate_windows_with_bed(std::vector<std::unique_ptr<
         target_window_trees_[it.first] = IntervalTreeInt64(std::move(it.second));
     }
 
-#ifdef BED_FEATURE_TEST
-    for (size_t i = 0; i < windows_.size(); ++i) {
-        std::cerr << "[window " << i << "] " << *windows_[i] << "\n";
-    }
-#endif
+// #ifdef BED_FEATURE_TEST
+//     for (size_t i = 0; i < windows_.size(); ++i) {
+//         std::cerr << "[window " << i << "] " << *windows_[i] << "\n";
+//     }
+// #endif
 
     find_overlap_breaking_points(overlaps, windows);
 
-#ifdef BED_FEATURE_TEST
-    for (uint64_t i = 0; i < overlaps.size(); ++i) {
-        const auto& sequence = sequences_[overlaps[i]->q_id()];
-        const std::vector<WindowInterval>& breaking_points = overlaps[i]->breaking_points();
+// #ifdef BED_FEATURE_TEST
+//     for (uint64_t i = 0; i < overlaps.size(); ++i) {
+//         const auto& sequence = sequences_[overlaps[i]->q_id()];
+//         const std::vector<WindowInterval>& breaking_points = overlaps[i]->breaking_points();
 
-        std::cerr << "overlap_id = " << i << "\n";
-        std::cerr << "    " << *overlaps[i] << "\n";
-        std::cerr << "All breaking points:\n";
-        for (uint32_t j = 0; j < breaking_points.size(); ++j) {
-            const auto& bp = breaking_points[j];
-            std::cerr << "[j = " << j << "] bp = " << bp << ", Window: " << *windows_[bp.window_id] << "\n";
-            if (bp.t_start < windows_[bp.window_id]->start() || bp.t_start >= windows_[bp.window_id]->end() ||
-                bp.t_end < windows_[bp.window_id]->start() || bp.t_end > windows_[bp.window_id]->end()) {
-                std::cerr << "ERROR! Coordiantes out of bounds!\n";
-                exit(1);
-            }
-        }
-        std::cerr << "\n";
-    }
-#endif
+//         std::cerr << "overlap_id = " << i << "\n";
+//         std::cerr << "    " << *overlaps[i] << "\n";
+//         std::cerr << "All breaking points:\n";
+//         for (uint32_t j = 0; j < breaking_points.size(); ++j) {
+//             const auto& bp = breaking_points[j];
+//             std::cerr << "[j = " << j << "] bp = " << bp << ", Window: " << *windows_[bp.window_id] << "\n";
+//             if (bp.t_start < windows_[bp.window_id]->start() || bp.t_start >= windows_[bp.window_id]->end() ||
+//                 bp.t_end < windows_[bp.window_id]->start() || bp.t_end > windows_[bp.window_id]->end()) {
+//                 std::cerr << "ERROR! Coordiantes out of bounds!\n";
+//                 exit(1);
+//             }
+//         }
+//         std::cerr << "\n";
+//     }
+// #endif
 
     assign_sequences_to_windows(overlaps, targets_size);
 }
@@ -701,26 +700,22 @@ void Polisher::polish(std::vector<std::unique_ptr<Sequence>>& dst,
 
         num_polished_windows += thread_futures[i].get() == true ? 1 : 0;
 
-#ifdef BED_FEATURE
-        // Add the sequence in between windows.
+        // BED region related: Add the sequence in between windows.
         if (windows_[i]->start() > prev_window_end) {
             uint64_t span = windows_[i]->start() - prev_window_end;
             polished_data += sequences_[windows_[i]->id()]->data().substr(prev_window_end, span);
         }
-#endif
 
         // Add the window consensus.
         polished_data += windows_[i]->consensus();
 
         if (i == windows_.size() - 1 || windows_[i + 1]->rank() == 0) {
-#ifdef BED_FEATURE
-            // Append the remaining suffix from the last window to the end of the target.
+            // BED region related: Append the remaining suffix from the last window to the end of the target.
             uint32_t tlen = sequences_[windows_[i]->id()]->data().size();
             if (windows_[i]->end() < tlen) {
                 uint64_t suffix_start = windows_[i]->end();
                 polished_data += sequences_[windows_[i]->id()]->data().substr(suffix_start);
             }
-#endif
 
             double polished_ratio = num_polished_windows /
                 static_cast<double>(windows_[i]->rank() + 1);

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -515,7 +515,7 @@ void Polisher::create_and_populate_windows_with_bed(std::vector<std::unique_ptr<
                     &(sequences_[t_id]->quality()[win_start]), length));
 
                 target_window_intervals_[t_id].emplace_back(IntervalInt64(win_start, win_start + length - 1, win_id));
-                windows[t_id].emplace_back(win_start, win_start + length, win_id);
+                windows[t_id].emplace_back(win_start, win_start + length - 1, win_id);
             }
         }
     }

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -623,8 +623,8 @@ void Polisher::polish(std::vector<std::unique_ptr<Sequence>>& dst,
 #ifdef BED_FEATURE
             // Append the remaining suffix from the last window to the end of the target.
             uint32_t tlen = sequences_[windows_[i]->id()]->data().size();
-            if ((windows_[i]->start() + windows_[i]->backbone_length()) < tlen) {
-                uint64_t suffix_start = windows_[i]->start() + windows_[i]->backbone_length();
+            if (windows_[i]->end() < tlen) {
+                uint64_t suffix_start = windows_[i]->end;
                 polished_data += sequences_[windows_[i]->id()]->data().substr(suffix_start);
             }
 #endif
@@ -644,7 +644,7 @@ void Polisher::polish(std::vector<std::unique_ptr<Sequence>>& dst,
             num_polished_windows = 0;
             polished_data.clear();
         }
-        prev_window_end = windows_[i]->start() + windows_[i]->backbone_length();
+        prev_window_end = windows_[i]->end();
         windows_[i].reset();
 
         if (logger_step != 0 && (i + 1) % logger_step == 0 && (i + 1) / logger_step < 20) {

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -319,7 +319,7 @@ void Polisher::initialize() {
         }
     } else {
         for (uint64_t t_id = 0; t_id < targets_size; ++t_id) {
-            target_bed_intervals_[t_id].emplace_back(IntervalInt64(0, sequences_[t_id]->data().size(), -1));
+            target_bed_intervals_[t_id].emplace_back(IntervalInt64(0, static_cast<int64_t>(sequences_[t_id]->data().size()) - 1, -1));
         }
     }
     // Sort target intervals.

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -624,7 +624,7 @@ void Polisher::polish(std::vector<std::unique_ptr<Sequence>>& dst,
             // Append the remaining suffix from the last window to the end of the target.
             uint32_t tlen = sequences_[windows_[i]->id()]->data().size();
             if (windows_[i]->end() < tlen) {
-                uint64_t suffix_start = windows_[i]->end;
+                uint64_t suffix_start = windows_[i]->end();
                 polished_data += sequences_[windows_[i]->id()]->data().substr(suffix_start);
             }
 #endif

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -10,7 +10,6 @@
 
 #include "overlap.hpp"
 #include "sequence.hpp"
-#include "window.hpp"
 #include "logger.hpp"
 #include "polisher.hpp"
 #ifdef CUDA_ENABLED
@@ -377,6 +376,13 @@ void Polisher::initialize() {
         it.wait();
     }
 
+    create_and_populate_windows(overlaps, targets_size, window_type);
+
+    logger_->log("[racon::Polisher::initialize] transformed data into windows");
+}
+
+void Polisher::create_and_populate_windows(std::vector<std::unique_ptr<Overlap>>& overlaps,
+        uint64_t targets_size, WindowType window_type) {
     find_overlap_breaking_points(overlaps);
 
     logger_->log();
@@ -455,8 +461,6 @@ void Polisher::initialize() {
 
         overlaps[i].reset();
     }
-
-    logger_->log("[racon::Polisher::initialize] transformed data into windows");
 }
 
 void Polisher::find_overlap_breaking_points(std::vector<std::unique_ptr<Overlap>>& overlaps)

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -377,8 +377,6 @@ void Polisher::initialize() {
     }
 
     create_and_populate_windows(overlaps, targets_size, window_type);
-
-    logger_->log("[racon::Polisher::initialize] transformed data into windows");
 }
 
 void Polisher::create_and_populate_windows(std::vector<std::unique_ptr<Overlap>>& overlaps,
@@ -461,6 +459,8 @@ void Polisher::create_and_populate_windows(std::vector<std::unique_ptr<Overlap>>
 
         overlaps[i].reset();
     }
+
+    logger_->log("[racon::Polisher::initialize] transformed data into windows");
 }
 
 void Polisher::find_overlap_breaking_points(std::vector<std::unique_ptr<Overlap>>& overlaps)
@@ -525,6 +525,13 @@ void Polisher::polish(std::vector<std::unique_ptr<Sequence>>& dst,
         polished_data += windows_[i]->consensus();
 
         if (i == windows_.size() - 1 || windows_[i + 1]->rank() == 0) {
+            // Append the remaining suffix from the last window to the end of the target.
+            uint32_t tlen = sequences_[windows_[i]->id()]->data().size();
+            if ((windows_[i]->start() + windows_[i]->backbone_length()) < tlen) {
+                uint64_t suffix_start = windows_[i]->start() + windows_[i]->backbone_length();
+                polished_data += sequences_[windows_[i]->id()]->data().substr(suffix_start);
+            }
+
             double polished_ratio = num_polished_windows /
                 static_cast<double>(windows_[i]->rank() + 1);
 

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -101,7 +101,6 @@ protected:
     std::vector<std::shared_ptr<spoa::AlignmentEngine>> alignment_engines_;
 
     std::vector<std::unique_ptr<Sequence>> sequences_;
-    std::unordered_map<int64_t, IntervalTreeInt64> target_trees_;
     std::vector<uint32_t> targets_coverages_;
     std::string dummy_quality_;
 
@@ -112,6 +111,9 @@ protected:
     std::unordered_map<std::thread::id, uint32_t> thread_to_id_;
 
     std::unique_ptr<Logger> logger_;
+
+    std::unordered_map<int64_t, std::vector<IntervalInt64>> target_intervals_;
+    std::unordered_map<int64_t, IntervalTreeInt64> target_trees_;
 };
 
 }

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -6,11 +6,12 @@
 
 #pragma once
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <vector>
 #include <memory>
 #include <unordered_map>
 #include <thread>
+#include "window.hpp"
 
 namespace bioparser {
     template<class T>
@@ -73,6 +74,8 @@ protected:
     Polisher(const Polisher&) = delete;
     const Polisher& operator=(const Polisher&) = delete;
     virtual void find_overlap_breaking_points(std::vector<std::unique_ptr<Overlap>>& overlaps);
+    void create_and_populate_windows(std::vector<std::unique_ptr<Overlap>>& overlaps,
+        uint64_t targets_size, WindowType window_type);
 
     std::unique_ptr<bioparser::Parser<Sequence>> sparser_;
     std::unique_ptr<bioparser::Parser<Overlap>> oparser_;

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -12,6 +12,9 @@
 #include <unordered_map>
 #include <thread>
 #include "window.hpp"
+#include "bed.hpp"
+#include "IntervalTree.h"
+#include <unordered_map>
 
 namespace bioparser {
     template<class T>
@@ -38,6 +41,10 @@ enum class PolisherType {
     kC, // Contig polishing
     kF // Fragment error correction
 };
+
+using IntervalTreeInt64 = IntervalTree<int64_t, size_t>;
+using IntervalVectorInt64 = IntervalTreeInt64::interval_vector;
+using IntervalInt64 = IntervalTreeInt64::interval;
 
 class Polisher;
 std::unique_ptr<Polisher> createPolisher(const std::string& sequences_path,
@@ -70,6 +77,7 @@ protected:
     Polisher(std::unique_ptr<bioparser::Parser<Sequence>> sparser,
         std::unique_ptr<bioparser::Parser<Overlap>> oparser,
         std::unique_ptr<bioparser::Parser<Sequence>> tparser,
+        std::vector<BedRecord> bed_records, bool use_bed,
         PolisherType type, uint32_t window_length, double quality_threshold,
         double error_threshold, bool trim, int8_t match, int8_t mismatch, int8_t gap,
         uint32_t num_threads);
@@ -83,6 +91,9 @@ protected:
     std::unique_ptr<bioparser::Parser<Overlap>> oparser_;
     std::unique_ptr<bioparser::Parser<Sequence>> tparser_;
 
+    std::vector<BedRecord> bed_records_;
+    bool use_bed_;
+
     PolisherType type_;
     double quality_threshold_;
     double error_threshold_;
@@ -90,6 +101,7 @@ protected:
     std::vector<std::shared_ptr<spoa::AlignmentEngine>> alignment_engines_;
 
     std::vector<std::unique_ptr<Sequence>> sequences_;
+    std::unordered_map<int64_t, IntervalTreeInt64> target_trees_;
     std::vector<uint32_t> targets_coverages_;
     std::string dummy_quality_;
 

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -108,6 +108,7 @@ protected:
 
     uint32_t window_length_;
     std::vector<std::shared_ptr<Window>> windows_;
+    std::vector<int64_t> id_to_first_window_id_;
 
     std::unique_ptr<thread_pool::ThreadPool> thread_pool_;
     std::unordered_map<std::thread::id, uint32_t> thread_to_id_;
@@ -119,7 +120,6 @@ protected:
 
     std::unordered_map<int64_t, std::vector<IntervalInt64>> target_window_intervals_;
     std::unordered_map<int64_t, IntervalTreeInt64> target_window_trees_;
-
 };
 
 }

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -79,12 +79,9 @@ protected:
         uint32_t num_threads);
     Polisher(const Polisher&) = delete;
     const Polisher& operator=(const Polisher&) = delete;
-    virtual void find_overlap_breaking_points(std::vector<std::unique_ptr<Overlap>>& overlaps);
     virtual void find_overlap_breaking_points(std::vector<std::unique_ptr<Overlap>>& overlaps,
         const std::unordered_map<int64_t, std::vector<std::tuple<int64_t, int64_t, int64_t>>>& windows);
 
-    void create_and_populate_windows(std::vector<std::unique_ptr<Overlap>>& overlaps,
-        uint64_t targets_size, WindowType window_type);
     void create_and_populate_windows_with_bed(std::vector<std::unique_ptr<Overlap>>& overlaps,
         uint64_t targets_size, WindowType window_type);
     void assign_sequences_to_windows(std::vector<std::unique_ptr<Overlap>>& overlaps, uint64_t targets_size);

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -42,6 +42,7 @@ enum class PolisherType {
 class Polisher;
 std::unique_ptr<Polisher> createPolisher(const std::string& sequences_path,
     const std::string& overlaps_path, const std::string& target_path,
+    const std::string& bed_path,
     PolisherType type, uint32_t window_length, double quality_threshold,
     double error_threshold, bool trim, int8_t match, int8_t mismatch, int8_t gap,
     uint32_t num_threads, uint32_t cuda_batches = 0,
@@ -59,6 +60,7 @@ public:
 
     friend std::unique_ptr<Polisher> createPolisher(const std::string& sequences_path,
         const std::string& overlaps_path, const std::string& target_path,
+        const std::string& bed_path,
         PolisherType type, uint32_t window_length, double quality_threshold,
         double error_threshold, bool trim, int8_t match, int8_t mismatch, int8_t gap,
         uint32_t num_threads, uint32_t cuda_batches, bool cuda_banded_alignment,

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -14,6 +14,7 @@
 #include "window.hpp"
 #include "bed.hpp"
 #include "IntervalTree.h"
+#include "util.hpp"
 #include <unordered_map>
 
 namespace bioparser {
@@ -29,7 +30,6 @@ namespace spoa {
     class AlignmentEngine;
 }
 
-
 namespace racon {
 
 class Sequence;
@@ -41,10 +41,6 @@ enum class PolisherType {
     kC, // Contig polishing
     kF // Fragment error correction
 };
-
-using IntervalTreeInt64 = IntervalTree<int64_t, size_t>;
-using IntervalVectorInt64 = IntervalTreeInt64::interval_vector;
-using IntervalInt64 = IntervalTreeInt64::interval;
 
 class Polisher;
 std::unique_ptr<Polisher> createPolisher(const std::string& sequences_path,

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -114,8 +114,12 @@ protected:
 
     std::unique_ptr<Logger> logger_;
 
-    std::unordered_map<int64_t, std::vector<IntervalInt64>> target_intervals_;
-    std::unordered_map<int64_t, IntervalTreeInt64> target_trees_;
+    std::unordered_map<int64_t, std::vector<IntervalInt64>> target_bed_intervals_;
+    std::unordered_map<int64_t, IntervalTreeInt64> target_bed_trees_;
+
+    std::unordered_map<int64_t, std::vector<IntervalInt64>> target_window_intervals_;
+    std::unordered_map<int64_t, IntervalTreeInt64> target_window_trees_;
+
 };
 
 }

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -80,10 +80,14 @@ protected:
     Polisher(const Polisher&) = delete;
     const Polisher& operator=(const Polisher&) = delete;
     virtual void find_overlap_breaking_points(std::vector<std::unique_ptr<Overlap>>& overlaps);
+    virtual void find_overlap_breaking_points(std::vector<std::unique_ptr<Overlap>>& overlaps,
+        const std::unordered_map<int64_t, std::vector<std::tuple<int64_t, int64_t, int64_t>>>& windows);
+
     void create_and_populate_windows(std::vector<std::unique_ptr<Overlap>>& overlaps,
         uint64_t targets_size, WindowType window_type);
     void create_and_populate_windows_with_bed(std::vector<std::unique_ptr<Overlap>>& overlaps,
         uint64_t targets_size, WindowType window_type);
+    void assign_sequences_to_windows(std::vector<std::unique_ptr<Overlap>>& overlaps, uint64_t targets_size);
 
     std::unique_ptr<bioparser::Parser<Sequence>> sparser_;
     std::unique_ptr<bioparser::Parser<Overlap>> oparser_;

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -86,6 +86,8 @@ protected:
     virtual void find_overlap_breaking_points(std::vector<std::unique_ptr<Overlap>>& overlaps);
     void create_and_populate_windows(std::vector<std::unique_ptr<Overlap>>& overlaps,
         uint64_t targets_size, WindowType window_type);
+    void create_and_populate_windows_with_bed(std::vector<std::unique_ptr<Overlap>>& overlaps,
+        uint64_t targets_size, WindowType window_type);
 
     std::unique_ptr<bioparser::Parser<Sequence>> sparser_;
     std::unique_ptr<bioparser::Parser<Overlap>> oparser_;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -41,7 +41,8 @@ std::vector<WindowInterval> generate_window_breakpoints(
     int64_t num_windows = static_cast<int64_t>(windows.size());
 
     bool found_first_match = false;
-    std::tuple<int64_t, int64_t, int64_t> first_match = {0, 0, 0}, last_match = {0, 0, 0};
+    std::tuple<int64_t, int64_t, int64_t> first_match(0, 0, 0);
+    std::tuple<int64_t, int64_t, int64_t> last_match(0, 0, 0);
 
     // The "-1" is because of the while loops below (increment is done at the top).
     int64_t q_pos = q_start - 1;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,0 +1,87 @@
+/*!
+ * @file util.cpp
+ *
+ * @brief Utility source file.
+ */
+
+#include "util.hpp"
+
+namespace racon {
+
+std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> find_breaking_points_from_cigar(
+            const std::string& cigar, std::vector<IntervalInt64> windows)
+{
+    std::sort(windows.begin(), windows.end(), [](const IntervalInt64& a, const IntervalInt64& b) {
+        return a.start < b.start;
+    });
+
+    std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> ret;
+
+    // // find breaking points from cigar
+    // std::vector<int32_t> window_ends;
+    // uint32_t w_offset = 0;
+    // for (uint32_t i = 0; i < t_end_; i += window_length) {
+    //     if (i > t_begin_) {
+    //         window_ends.emplace_back(i - 1);
+    //     } else {
+    //         ++w_offset;
+    //     }
+    // }
+    // window_ends.emplace_back(t_end_ - 1);
+
+    // uint32_t w = 0;
+    // bool found_first_match = false;
+    // std::tuple<uint32_t, uint32_t, uint32_t> first_match = {0, 0, 0}, last_match = {0, 0, 0};
+
+    // int32_t q_ptr = (strand_ ? (q_length_ - q_end_) : q_begin_) - 1;
+    // int32_t t_ptr = t_begin_ - 1;
+
+    // for (uint32_t i = 0, j = 0; i < cigar_.size(); ++i) {
+    //     if (cigar_[i] == 'M' || cigar_[i] == '=' || cigar_[i] == 'X') {
+    //         uint32_t k = 0, num_bases = atoi(&cigar_[j]);
+    //         j = i + 1;
+    //         while (k < num_bases) {
+    //             ++q_ptr;
+    //             ++t_ptr;
+
+    //             if (!found_first_match) {
+    //                 found_first_match = true;
+    //                 first_match = std::make_tuple(t_ptr, q_ptr, w + w_offset);
+    //             }
+    //             last_match = std::make_tuple(t_ptr + 1, q_ptr + 1, w + w_offset);
+    //             if (t_ptr == window_ends[w]) {
+    //                 if (found_first_match) {
+    //                     breaking_points_.emplace_back(first_match);
+    //                     breaking_points_.emplace_back(last_match);
+    //                 }
+    //                 found_first_match = false;
+    //                 ++w;
+    //             }
+
+    //             ++k;
+    //         }
+    //     } else if (cigar_[i] == 'I') {
+    //         q_ptr += atoi(&cigar_[j]);
+    //         j = i + 1;
+    //     } else if (cigar_[i] == 'D' || cigar_[i] == 'N') {
+    //         uint32_t k = 0, num_bases = atoi(&cigar_[j]);
+    //         j = i + 1;
+    //         while (k < num_bases) {
+    //             ++t_ptr;
+    //             if (t_ptr == window_ends[w]) {
+    //                 if (found_first_match) {
+    //                     breaking_points_.emplace_back(first_match);
+    //                     breaking_points_.emplace_back(last_match);
+    //                 }
+    //                 found_first_match = false;
+    //                 ++w;
+    //             }
+    //             ++k;
+    //         }
+    //     } else if (cigar_[i] == 'S' || cigar_[i] == 'H' || cigar_[i] == 'P') {
+    //         j = i + 1;
+    //     }
+    // }
+}
+
+}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8,80 +8,158 @@
 
 namespace racon {
 
-std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> find_breaking_points_from_cigar(
-            const std::string& cigar, std::vector<IntervalInt64> windows)
+// Tuple of: <start, end, window_id>
+// using WindowInterval = std::vector<std::tuple<uint32_t, uint32_t, uint32_t>>;
+
+// std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> find_breaking_points_from_cigar(
+//             const std::string& cigar, int32_t q_start, int32_t t_start,
+//             std::vector<IntervalInt64> windows)
+// {
+// }
+
+/*
+ * \param windows Vector of tuples, where each tuple element is: <start, end, window_id>.
+*/
+std::vector<WindowInterval> generate_window_breakpoints(
+            const std::string& cigar, int64_t q_start, int64_t t_start,
+            std::vector<std::tuple<int64_t, int64_t, int64_t>> windows)
 {
-    std::sort(windows.begin(), windows.end(), [](const IntervalInt64& a, const IntervalInt64& b) {
-        return a.start < b.start;
+    std::vector<WindowInterval> ret;
+
+    if (windows.empty()) {
+        return ret;
+    }
+
+    std::sort(windows.begin(), windows.end(),
+                [](const std::tuple<int64_t, int64_t, int64_t>& a,
+                    const std::tuple<int64_t, int64_t, int64_t>& b) {
+        return std::get<0>(a) < std::get<0>(b);
     });
 
-    std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> ret;
+    // Avoid using the operators.
+    const char* cigar_str = cigar.c_str();
+    int64_t num_windows = static_cast<int64_t>(windows.size());
 
-    // // find breaking points from cigar
-    // std::vector<int32_t> window_ends;
-    // uint32_t w_offset = 0;
-    // for (uint32_t i = 0; i < t_end_; i += window_length) {
-    //     if (i > t_begin_) {
-    //         window_ends.emplace_back(i - 1);
-    //     } else {
-    //         ++w_offset;
-    //     }
-    // }
-    // window_ends.emplace_back(t_end_ - 1);
+    bool found_first_match = false;
+    std::tuple<int64_t, int64_t, int64_t> first_match = {0, 0, 0}, last_match = {0, 0, 0};
 
-    // uint32_t w = 0;
-    // bool found_first_match = false;
-    // std::tuple<uint32_t, uint32_t, uint32_t> first_match = {0, 0, 0}, last_match = {0, 0, 0};
+    // The "-1" is because of the while loops below (increment is done at the top).
+    int64_t q_pos = q_start - 1;
+    int64_t t_pos = t_start - 1;
+    int64_t curr_w = 0;
 
-    // int32_t q_ptr = (strand_ ? (q_length_ - q_end_) : q_begin_) - 1;
-    // int32_t t_ptr = t_begin_ - 1;
+    while (curr_w < num_windows && std::get<1>(windows[curr_w]) < t_start) {
+        ++curr_w;
+    }
 
-    // for (uint32_t i = 0, j = 0; i < cigar_.size(); ++i) {
-    //     if (cigar_[i] == 'M' || cigar_[i] == '=' || cigar_[i] == 'X') {
-    //         uint32_t k = 0, num_bases = atoi(&cigar_[j]);
-    //         j = i + 1;
-    //         while (k < num_bases) {
-    //             ++q_ptr;
-    //             ++t_ptr;
+    for (uint32_t i = 0, j = 0; i < cigar.size(); ++i) {
+        if (cigar_str[i] == 'M' || cigar_str[i] == '=' || cigar_str[i] == 'X') {
+            uint32_t num_bases = atoi(&cigar_str[j]);
+            j = i + 1;
+            for (uint32_t k = 0; k < num_bases; ++k) {
+                ++q_pos;
+                ++t_pos;
 
-    //             if (!found_first_match) {
-    //                 found_first_match = true;
-    //                 first_match = std::make_tuple(t_ptr, q_ptr, w + w_offset);
-    //             }
-    //             last_match = std::make_tuple(t_ptr + 1, q_ptr + 1, w + w_offset);
-    //             if (t_ptr == window_ends[w]) {
-    //                 if (found_first_match) {
-    //                     breaking_points_.emplace_back(first_match);
-    //                     breaking_points_.emplace_back(last_match);
-    //                 }
-    //                 found_first_match = false;
-    //                 ++w;
-    //             }
+                while (curr_w < num_windows && std::get<1>(windows[curr_w]) < t_pos) {
+                    ++curr_w;
+                }
+                if (curr_w >= num_windows) {
+                    break;
+                }
 
-    //             ++k;
-    //         }
-    //     } else if (cigar_[i] == 'I') {
-    //         q_ptr += atoi(&cigar_[j]);
-    //         j = i + 1;
-    //     } else if (cigar_[i] == 'D' || cigar_[i] == 'N') {
-    //         uint32_t k = 0, num_bases = atoi(&cigar_[j]);
-    //         j = i + 1;
-    //         while (k < num_bases) {
-    //             ++t_ptr;
-    //             if (t_ptr == window_ends[w]) {
-    //                 if (found_first_match) {
-    //                     breaking_points_.emplace_back(first_match);
-    //                     breaking_points_.emplace_back(last_match);
-    //                 }
-    //                 found_first_match = false;
-    //                 ++w;
-    //             }
-    //             ++k;
-    //         }
-    //     } else if (cigar_[i] == 'S' || cigar_[i] == 'H' || cigar_[i] == 'P') {
-    //         j = i + 1;
-    //     }
-    // }
+                const auto& win_start = std::get<0>(windows[curr_w]);
+                const auto& win_end = std::get<1>(windows[curr_w]);
+                const auto& win_id = std::get<2>(windows[curr_w]);
+
+                if (t_pos < win_start) {
+                    continue;
+                }
+
+                if (!found_first_match) {
+                    found_first_match = true;
+                    first_match = std::make_tuple(t_pos, q_pos, win_id);
+                }
+                last_match = std::make_tuple(t_pos + 1, q_pos + 1, win_id);
+                if (t_pos == (win_end - 1)) {
+                    if (found_first_match) {
+                        WindowInterval wi(
+                                std::get<1>(first_match),
+                                std::get<1>(last_match),
+                                std::get<0>(first_match),
+                                std::get<0>(last_match),
+                                std::get<2>(last_match));
+                        ret.emplace_back(std::move(wi));
+                    }
+                    found_first_match = false;
+                    ++curr_w;
+                    if (curr_w >= num_windows) {
+                        break;
+                    }
+                }
+            }
+        } else if (cigar_str[i] == 'I') {
+            q_pos += atoi(&cigar_str[j]);
+            j = i + 1;
+        } else if (cigar_str[i] == 'D' || cigar_str[i] == 'N') {
+            uint32_t num_bases = atoi(&cigar_str[j]);
+            j = i + 1;
+            for (uint32_t k = 0; k < num_bases; ++k) {
+                ++t_pos;
+
+                while (curr_w < num_windows && std::get<1>(windows[curr_w]) < t_pos) {
+                    ++curr_w;
+                }
+                if (curr_w >= num_windows) {
+                    break;
+                }
+
+                const auto& win_start = std::get<0>(windows[curr_w]);
+                const auto& win_end = std::get<1>(windows[curr_w]);
+
+                if (t_pos < win_start) {
+                    continue;
+                }
+
+                if (t_pos == (win_end - 1)) {
+                    if (found_first_match) {
+                        WindowInterval wi(
+                                std::get<1>(first_match),
+                                std::get<1>(last_match),
+                                std::get<0>(first_match),
+                                std::get<0>(last_match),
+                                std::get<2>(last_match));
+                        ret.emplace_back(std::move(wi));
+                    }
+                    found_first_match = false;
+                    ++curr_w;
+                    if (curr_w >= num_windows) {
+                        break;
+                    }
+                }
+            }
+        } else if (cigar_str[i] == 'S' || cigar_str[i] == 'H' || cigar_str[i] == 'P') {
+            j = i + 1;
+        }
+    }
+
+    // Add the final piece.
+    if (curr_w < static_cast<int64_t>(windows.size())) {
+        const auto& win_start = std::get<0>(windows[curr_w]);
+        const auto& win_end = std::get<1>(windows[curr_w]);
+        const auto& final_t_start = std::get<0>(first_match);
+        const auto& final_t_end = std::get<0>(last_match);
+        if (found_first_match && final_t_start >= win_start && final_t_end <= win_end) {
+            WindowInterval wi(
+                    std::get<1>(first_match),
+                    std::get<1>(last_match),
+                    std::get<0>(first_match),
+                    std::get<0>(last_match),
+                    std::get<2>(last_match));
+            ret.emplace_back(std::move(wi));
+        }
+    }
+
+    return ret;
 }
 
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -49,7 +49,7 @@ std::vector<WindowInterval> generate_window_breakpoints(
     int64_t t_pos = t_start - 1;
     int64_t curr_w = 0;
 
-    while (curr_w < num_windows && std::get<1>(windows[curr_w]) < t_start) {
+    while (curr_w < num_windows && std::get<1>(windows[curr_w]) <= t_start) {
         ++curr_w;
     }
 
@@ -61,7 +61,7 @@ std::vector<WindowInterval> generate_window_breakpoints(
                 ++q_pos;
                 ++t_pos;
 
-                while (curr_w < num_windows && std::get<1>(windows[curr_w]) < t_pos) {
+                while (curr_w < num_windows && std::get<1>(windows[curr_w]) <= t_pos) {
                     ++curr_w;
                 }
                 if (curr_w >= num_windows) {
@@ -107,7 +107,7 @@ std::vector<WindowInterval> generate_window_breakpoints(
             for (uint32_t k = 0; k < num_bases; ++k) {
                 ++t_pos;
 
-                while (curr_w < num_windows && std::get<1>(windows[curr_w]) < t_pos) {
+                while (curr_w < num_windows && std::get<1>(windows[curr_w]) <= t_pos) {
                     ++curr_w;
                 }
                 if (curr_w >= num_windows) {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -1,0 +1,26 @@
+/*!
+ * @file util.hpp
+ *
+ * @brief Utility functions used throughout the code.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace racon {
+
+template<typename T>
+bool transmuteId(const std::unordered_map<T, uint64_t>& t_to_id, const T& t,
+    uint64_t& id) {
+
+    auto it = t_to_id.find(t);
+    if (it == t_to_id.end()) {
+        return false;
+    }
+    id = it->second;
+    return true;
+}
+
+}

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -38,12 +38,7 @@ public:
                     && t_end == rhs.t_end && window_id == rhs.window_id;
     }
 
-    std::ostream& operator<<(std::ostream& os) const {
-        os << "q_start = " << q_start << ", q_end = " << q_end
-            << ", t_start = " << t_start << "t_end = " << t_end
-            << "window_id = " << window_id;
-        return os;
-    }
+    friend std::ostream& operator<<(::std::ostream& os, const WindowInterval& a);
 
     int64_t q_start = 0;
     int64_t q_end = 0;
@@ -51,6 +46,13 @@ public:
     int64_t t_end = 0;
     int64_t window_id = -1;
 };
+
+inline std::ostream& operator<<(::std::ostream& os, const WindowInterval& a) {
+    os << "q_start = " << a.q_start << ", q_end = " << a.q_end
+        << ", t_start = " << a.t_start << ", t_end = " << a.t_end
+        << ", window_id = " << a.window_id;
+    return os;
+}
 
 template<typename T>
 bool transmuteId(const std::unordered_map<T, uint64_t>& t_to_id, const T& t,

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -6,8 +6,16 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
+#include <vector>
 #include <unordered_map>
+#include <tuple>
+#include "IntervalTree.h"
+
+using IntervalTreeInt64 = IntervalTree<int64_t, size_t>;
+using IntervalVectorInt64 = IntervalTreeInt64::interval_vector;
+using IntervalInt64 = IntervalTreeInt64::interval;
 
 namespace racon {
 
@@ -22,5 +30,8 @@ bool transmuteId(const std::unordered_map<T, uint64_t>& t_to_id, const T& t,
     id = it->second;
     return true;
 }
+
+std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> find_breaking_points_from_cigar(
+            const std::string& cigar, std::vector<IntervalInt64> windows);
 
 }

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <ostream>
 #include <vector>
 #include <unordered_map>
 #include <tuple>
@@ -18,6 +19,38 @@ using IntervalVectorInt64 = IntervalTreeInt64::interval_vector;
 using IntervalInt64 = IntervalTreeInt64::interval;
 
 namespace racon {
+
+class WindowInterval {
+public:
+    WindowInterval() = default;
+
+    WindowInterval(int64_t _q_start, int64_t _q_end, int64_t _t_start, int64_t _t_end, int64_t _window_id)
+        : q_start(_q_start)
+        , q_end(_q_end)
+        , t_start(_t_start)
+        , t_end(_t_end)
+        , window_id(_window_id)
+    {}
+
+    bool operator==(const WindowInterval& rhs) const
+    {
+        return q_start == rhs.q_start && q_end == rhs.q_end && t_start == rhs.t_start
+                    && t_end == rhs.t_end && window_id == rhs.window_id;
+    }
+
+    std::ostream& operator<<(std::ostream& os) const {
+        os << "q_start = " << q_start << ", q_end = " << q_end
+            << ", t_start = " << t_start << "t_end = " << t_end
+            << "window_id = " << window_id;
+        return os;
+    }
+
+    int64_t q_start = 0;
+    int64_t q_end = 0;
+    int64_t t_start = 0;
+    int64_t t_end = 0;
+    int64_t window_id = -1;
+};
 
 template<typename T>
 bool transmuteId(const std::unordered_map<T, uint64_t>& t_to_id, const T& t,
@@ -31,7 +64,8 @@ bool transmuteId(const std::unordered_map<T, uint64_t>& t_to_id, const T& t,
     return true;
 }
 
-std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> find_breaking_points_from_cigar(
-            const std::string& cigar, std::vector<IntervalInt64> windows);
+std::vector<WindowInterval> generate_window_breakpoints(
+            const std::string& cigar, int64_t q_start, int64_t t_start,
+            std::vector<std::tuple<int64_t, int64_t, int64_t>> windows);
 
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -148,6 +148,7 @@ std::ostream& operator<<(std::ostream& os, const Window& a)
     os << "Window: id = " << a.id_ << ", rank = " << a.rank_ << ", type = "
         << ((a.type_ == WindowType::kNGS) ? "NGS" : "TGS")
         << ", start = " << a.start_
+        << ", end = " << a.end_
         << ", backbone_len = " << a.backbone_length()
         << ", consensus_len = " << a.consensus_.size()
         << ", seqs_len = " << a.sequences_.size()

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -55,7 +55,8 @@ void Window::add_layer(const char* sequence, uint32_t sequence_length,
     }
     if (begin >= end || begin > sequences_.front().second || end > sequences_.front().second) {
         fprintf(stderr, "[racon::Window::add_layer] error: "
-            "layer begin and end positions are invalid!\n");
+            "layer begin and end positions are invalid! begin = %lu, end = %lu, backbone_len = %lu\n",
+            begin, end, sequences_.front().second);
         exit(1);
     }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -13,8 +13,8 @@
 namespace racon {
 
 std::shared_ptr<Window> createWindow(uint64_t id, uint32_t rank, WindowType type,
-    const char* backbone, uint32_t backbone_length, const char* quality,
-    uint32_t quality_length) {
+    uint32_t backbone_start, const char* backbone, uint32_t backbone_length,
+    const char* quality, uint32_t quality_length) {
 
     if (backbone_length == 0 || backbone_length != quality_length) {
         fprintf(stderr, "[racon::createWindow] error: "
@@ -22,13 +22,14 @@ std::shared_ptr<Window> createWindow(uint64_t id, uint32_t rank, WindowType type
         exit(1);
     }
 
-    return std::shared_ptr<Window>(new Window(id, rank, type, backbone,
+    return std::shared_ptr<Window>(new Window(id, rank, type, backbone_start, backbone,
         backbone_length, quality, quality_length));
 }
 
-Window::Window(uint64_t id, uint32_t rank, WindowType type, const char* backbone,
-    uint32_t backbone_length, const char* quality, uint32_t quality_length)
-        : id_(id), rank_(rank), type_(type), consensus_(), sequences_(),
+Window::Window(uint64_t id, uint32_t rank, WindowType type, uint32_t backbone_start,
+    const char* backbone, uint32_t backbone_length, const char* quality,
+    uint32_t quality_length)
+        : id_(id), rank_(rank), type_(type), start_(backbone_start), consensus_(), sequences_(),
         qualities_(), positions_() {
 
     sequences_.emplace_back(backbone, backbone_length);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -13,7 +13,7 @@
 namespace racon {
 
 std::shared_ptr<Window> createWindow(uint64_t id, uint32_t rank, WindowType type,
-    uint32_t backbone_start, const char* backbone, uint32_t backbone_length,
+    uint32_t window_start, const char* backbone, uint32_t backbone_length,
     const char* quality, uint32_t quality_length) {
 
     if (backbone_length == 0 || backbone_length != quality_length) {
@@ -22,14 +22,15 @@ std::shared_ptr<Window> createWindow(uint64_t id, uint32_t rank, WindowType type
         exit(1);
     }
 
-    return std::shared_ptr<Window>(new Window(id, rank, type, backbone_start, backbone,
+    return std::shared_ptr<Window>(new Window(id, rank, type, window_start, backbone,
         backbone_length, quality, quality_length));
 }
 
-Window::Window(uint64_t id, uint32_t rank, WindowType type, uint32_t backbone_start,
+Window::Window(uint64_t id, uint32_t rank, WindowType type, uint32_t window_start,
     const char* backbone, uint32_t backbone_length, const char* quality,
     uint32_t quality_length)
-        : id_(id), rank_(rank), type_(type), start_(backbone_start), consensus_(), sequences_(),
+        : id_(id), rank_(rank), type_(type), start_(window_start), end_(window_start + backbone_length),
+        consensus_(), sequences_(),
         qualities_(), positions_() {
 
     sequences_.emplace_back(backbone, backbone_length);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -142,4 +142,17 @@ bool Window::generate_consensus(std::shared_ptr<spoa::AlignmentEngine> alignment
     return true;
 }
 
+std::ostream& operator<<(std::ostream& os, const Window& a)
+{
+    os << "Window: id = " << a.id_ << ", rank = " << a.rank_ << ", type = "
+        << ((a.type_ == WindowType::kNGS) ? "NGS" : "TGS")
+        << ", start = " << a.start_
+        << ", backbone_len = " << a.backbone_length()
+        << ", consensus_len = " << a.consensus_.size()
+        << ", seqs_len = " << a.sequences_.size()
+        << ", quals_len = " << a.qualities_.size()
+        << ", pos_len = " << a.positions_.size();
+    return os;
+}
+
 }

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <vector>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <utility>
 
@@ -62,9 +63,12 @@ public:
         WindowType type, uint32_t backbone_start, const char* backbone,
         uint32_t backbone_length, const char* quality, uint32_t quality_length);
 
+    friend std::ostream& operator<<(std::ostream& os, const Window& a);
+
 #ifdef CUDA_ENABLED
     friend class CUDABatchProcessor;
 #endif
+
 private:
     Window(uint64_t id, uint32_t rank, WindowType type, uint32_t backbone_start,
         const char* backbone, uint32_t backbone_length, const char* quality,
@@ -81,5 +85,7 @@ private:
     std::vector<std::pair<const char*, uint32_t>> qualities_;
     std::vector<std::pair<uint32_t, uint32_t>> positions_;
 };
+
+std::ostream& operator<<(std::ostream& os, const Window& a);
 
 }

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -26,7 +26,7 @@ enum class WindowType {
 
 class Window;
 std::shared_ptr<Window> createWindow(uint64_t id, uint32_t rank, WindowType type,
-    uint32_t backbone_start, const char* backbone, uint32_t backbone_length, const char* quality,
+    uint32_t window_start, const char* backbone, uint32_t backbone_length, const char* quality,
     uint32_t quality_length);
 
 class Window {
@@ -56,6 +56,10 @@ public:
         return start_;
     }
 
+    uint32_t end() const {
+        return end_;
+    }
+
     bool generate_consensus(std::shared_ptr<spoa::AlignmentEngine> alignment_engine,
         bool trim);
 
@@ -64,7 +68,7 @@ public:
         uint32_t end);
 
     friend std::shared_ptr<Window> createWindow(uint64_t id, uint32_t rank,
-        WindowType type, uint32_t backbone_start, const char* backbone,
+        WindowType type, uint32_t window_start, const char* backbone,
         uint32_t backbone_length, const char* quality, uint32_t quality_length);
 
     friend std::ostream& operator<<(std::ostream& os, const Window& a);
@@ -74,7 +78,7 @@ public:
 #endif
 
 private:
-    Window(uint64_t id, uint32_t rank, WindowType type, uint32_t backbone_start,
+    Window(uint64_t id, uint32_t rank, WindowType type, uint32_t window_start,
         const char* backbone, uint32_t backbone_length, const char* quality,
         uint32_t quality_length);
     Window(const Window&) = delete;
@@ -84,6 +88,7 @@ private:
     uint32_t rank_;
     WindowType type_;
     uint32_t start_;
+    uint32_t end_;
     std::string consensus_;
     std::vector<std::pair<const char*, uint32_t>> sequences_;
     std::vector<std::pair<const char*, uint32_t>> qualities_;

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -25,7 +25,7 @@ enum class WindowType {
 
 class Window;
 std::shared_ptr<Window> createWindow(uint64_t id, uint32_t rank, WindowType type,
-    const char* backbone, uint32_t backbone_length, const char* quality,
+    uint32_t backbone_start, const char* backbone, uint32_t backbone_length, const char* quality,
     uint32_t quality_length);
 
 class Window {
@@ -44,6 +44,13 @@ public:
         return consensus_;
     }
 
+    uint32_t backbone_length() const {
+        if (sequences_.empty()) {
+            return 0;
+        }
+        return sequences_.front().second;
+    }
+
     bool generate_consensus(std::shared_ptr<spoa::AlignmentEngine> alignment_engine,
         bool trim);
 
@@ -52,21 +59,23 @@ public:
         uint32_t end);
 
     friend std::shared_ptr<Window> createWindow(uint64_t id, uint32_t rank,
-        WindowType type, const char* backbone, uint32_t backbone_length,
-        const char* quality, uint32_t quality_length);
+        WindowType type, uint32_t backbone_start, const char* backbone,
+        uint32_t backbone_length, const char* quality, uint32_t quality_length);
 
 #ifdef CUDA_ENABLED
     friend class CUDABatchProcessor;
 #endif
 private:
-    Window(uint64_t id, uint32_t rank, WindowType type, const char* backbone,
-        uint32_t backbone_length, const char* quality, uint32_t quality_length);
+    Window(uint64_t id, uint32_t rank, WindowType type, uint32_t backbone_start,
+        const char* backbone, uint32_t backbone_length, const char* quality,
+        uint32_t quality_length);
     Window(const Window&) = delete;
     const Window& operator=(const Window&) = delete;
 
     uint64_t id_;
     uint32_t rank_;
     WindowType type_;
+    uint32_t start_;
     std::string consensus_;
     std::vector<std::pair<const char*, uint32_t>> sequences_;
     std::vector<std::pair<const char*, uint32_t>> qualities_;

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -52,6 +52,10 @@ public:
         return sequences_.front().second;
     }
 
+    uint32_t start() const {
+        return start_;
+    }
+
     bool generate_consensus(std::shared_ptr<spoa::AlignmentEngine> alignment_engine,
         bool trim);
 

--- a/test/bed_test.cpp
+++ b/test/bed_test.cpp
@@ -1,0 +1,96 @@
+/*!
+ * @file bed_test.cpp
+ *
+ * @brief Unit tests for the BED parser.
+ */
+
+#include "gtest/gtest.h"
+#include "racon_test_config.h"
+#include "bed.hpp"
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+TEST(BedFile, DeserializeTests) {
+    // Tuple: test_name, input line, expected record, expected return value, expected to throw.
+    std::vector<std::tuple<std::string, std::string, racon::BedRecord, bool, bool>> test_data = {
+        {"Empty input", "", racon::BedRecord(), false,false},
+        {"Three columns", "chr01 0 1000", racon::BedRecord("chr01", 0, 1000), true, false},
+        {"Multiple columns", "chr01 1000 2000 some other columns that are ignored", racon::BedRecord("chr01", 1000, 2000), true, false},
+        {"Invalid BED line", "bad_bed", racon::BedRecord(), true, true},
+    };
+
+    for (const auto& single_test: test_data) {
+        const std::string& test_name = std::get<0>(single_test);
+        const std::string& in_line = std::get<1>(single_test);
+        const racon::BedRecord& expected_record = std::get<2>(single_test);
+        const bool expected_rv = std::get<3>(single_test);
+        const bool expected_throw = std::get<4>(single_test);
+
+        SCOPED_TRACE(test_name);
+
+        if (expected_throw) {
+            EXPECT_THROW(
+                {
+                    racon::BedRecord record;
+                    racon::BedFile::Deserialize(in_line, record);
+                },
+                std::runtime_error);
+        } else {
+            racon::BedRecord record;
+            const bool rv = racon::BedFile::Deserialize(in_line, record);
+            EXPECT_EQ(expected_record, record);
+            EXPECT_EQ(expected_rv, rv);
+        }
+
+    }
+}
+
+TEST(BedReader, AllTests) {
+    // Tuple: test_name, input line, expected record, expected return value.
+    std::vector<std::tuple<std::string, std::string, std::vector<racon::BedRecord>, bool>> test_data = {
+        {"Empty input", "", {}, false},
+        {"Normal BED file",
+R"(chr01 0 1000
+chr02 1000 2000
+chr03 2000 3000
+)",
+            {
+                racon::BedRecord("chr01", 0, 1000),
+                racon::BedRecord("chr02", 1000, 2000),
+                racon::BedRecord("chr03", 2000, 3000),
+            },
+            false
+        },
+        {"Normal BED file",
+R"(chr01 0 1000
+bad_line
+)",
+            {}, true
+        },
+
+    };
+
+    for (const auto& single_test: test_data) {
+        const std::string& test_name = std::get<0>(single_test);
+        const std::string in_line = std::get<1>(single_test);
+        const std::vector<racon::BedRecord>& expected_records = std::get<2>(single_test);
+        const bool expected_throw = std::get<3>(single_test);
+
+        SCOPED_TRACE(test_name);
+
+        std::istringstream iss(in_line);
+
+        if (expected_throw) {
+            EXPECT_THROW(
+                {
+                    std::vector<racon::BedRecord> records = racon::BedReader::ReadAll(iss);
+                },
+                std::runtime_error);
+        } else {
+            std::vector<racon::BedRecord> records = racon::BedReader::ReadAll(iss);
+            EXPECT_EQ(expected_records, records);
+        }
+    }
+}

--- a/test/bed_test.cpp
+++ b/test/bed_test.cpp
@@ -14,11 +14,12 @@
 
 TEST(BedFile, DeserializeTests) {
     // Tuple: test_name, input line, expected record, expected return value, expected to throw.
+    using TestTupleType = std::tuple<std::string, std::string, racon::BedRecord, bool, bool>;
     std::vector<std::tuple<std::string, std::string, racon::BedRecord, bool, bool>> test_data{
-        {"Empty input", "", racon::BedRecord(), false,false},
-        {"Three columns", "chr01 0 1000", racon::BedRecord("chr01", 0, 1000), true, false},
-        {"Multiple columns", "chr01 1000 2000 some other columns that are ignored", racon::BedRecord("chr01", 1000, 2000), true, false},
-        {"Invalid BED line", "bad_bed", racon::BedRecord(), true, true},
+        TestTupleType("Empty input", "", racon::BedRecord(), false,false),
+        TestTupleType("Three columns", "chr01 0 1000", racon::BedRecord("chr01", 0, 1000), true, false),
+        TestTupleType("Multiple columns", "chr01 1000 2000 some other columns that are ignored", racon::BedRecord("chr01", 1000, 2000), true, false),
+        TestTupleType("Invalid BED line", "bad_bed", racon::BedRecord(), true, true),
     };
 
     for (const auto& single_test: test_data) {
@@ -49,26 +50,30 @@ TEST(BedFile, DeserializeTests) {
 
 TEST(BedReader, AllTests) {
     // Tuple: test_name, input line, expected record, expected return value.
+    using TestTupleType = std::tuple<std::string, std::string, std::vector<racon::BedRecord>, bool>;
     std::vector<std::tuple<std::string, std::string, std::vector<racon::BedRecord>, bool>> test_data {
-        {"Empty input", "", {}, false},
-        {"Normal BED file",
-R"(chr01 0 1000
+        TestTupleType("Empty input", "", {}, false),
+
+        TestTupleType(
+            "Normal BED file",
+            R"(chr01 0 1000
 chr02 1000 2000
 chr03 2000 3000
 )",
-            {
+            std::vector<racon::BedRecord>{
                 racon::BedRecord("chr01", 0, 1000),
                 racon::BedRecord("chr02", 1000, 2000),
                 racon::BedRecord("chr03", 2000, 3000),
             },
             false
-        },
-        {"Normal BED file",
-R"(chr01 0 1000
+        ),
+        TestTupleType(
+            "Normal BED file",
+            R"(chr01 0 1000
 bad_line
 )",
-            {}, true
-        },
+            std::vector<racon::BedRecord>(), true
+        ),
 
     };
 

--- a/test/bed_test.cpp
+++ b/test/bed_test.cpp
@@ -14,7 +14,7 @@
 
 TEST(BedFile, DeserializeTests) {
     // Tuple: test_name, input line, expected record, expected return value, expected to throw.
-    std::vector<std::tuple<std::string, std::string, racon::BedRecord, bool, bool>> test_data = {
+    std::vector<std::tuple<std::string, std::string, racon::BedRecord, bool, bool>> test_data{
         {"Empty input", "", racon::BedRecord(), false,false},
         {"Three columns", "chr01 0 1000", racon::BedRecord("chr01", 0, 1000), true, false},
         {"Multiple columns", "chr01 1000 2000 some other columns that are ignored", racon::BedRecord("chr01", 1000, 2000), true, false},
@@ -49,7 +49,7 @@ TEST(BedFile, DeserializeTests) {
 
 TEST(BedReader, AllTests) {
     // Tuple: test_name, input line, expected record, expected return value.
-    std::vector<std::tuple<std::string, std::string, std::vector<racon::BedRecord>, bool>> test_data = {
+    std::vector<std::tuple<std::string, std::string, std::vector<racon::BedRecord>, bool>> test_data {
         {"Empty input", "", {}, false},
         {"Normal BED file",
 R"(chr01 0 1000

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,5 +1,6 @@
 racon_test_cpp_sources = files([
-  'racon_test.cpp'
+  'bed_test.cpp',
+  'racon_test.cpp',
 ])
 
 racon_test_include_directories = [include_directories('.')]

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,5 +1,6 @@
 racon_test_cpp_sources = files([
   'bed_test.cpp',
+  'util_test.cpp',
   'racon_test.cpp',
 ])
 

--- a/test/racon_test.cpp
+++ b/test/racon_test.cpp
@@ -32,8 +32,10 @@ public:
         int8_t match, int8_t mismatch, int8_t gap, uint32_t cuda_batches = 0,
         bool cuda_banded_alignment = false, uint32_t cudaaligner_batches = 0) {
 
+        const std::string bed_path; // Intentionally empty.
+
         polisher = racon::createPolisher(sequences_path, overlaps_path, target_path,
-            type, window_length, quality_threshold, error_threshold, true, match,
+            bed_path, type, window_length, quality_threshold, error_threshold, true, match,
             mismatch, gap, 4, cuda_batches, cuda_banded_alignment, cudaaligner_batches);
     }
 
@@ -53,18 +55,18 @@ public:
 };
 
 TEST(RaconInitializeTest, PolisherTypeError) {
-    EXPECT_DEATH((racon::createPolisher("", "", "", static_cast<racon::PolisherType>(3),
+    EXPECT_DEATH((racon::createPolisher("", "", "", "", static_cast<racon::PolisherType>(3),
         0, 0, 0, 0, 0, 0, 0, 0)), ".racon::createPolisher. error: invalid polisher"
         " type!");
 }
 
 TEST(RaconInitializeTest, WindowLengthError) {
-    EXPECT_DEATH((racon::createPolisher("", "", "", racon::PolisherType::kC, 0,
+    EXPECT_DEATH((racon::createPolisher("", "", "", "", racon::PolisherType::kC, 0,
         0, 0, 0, 0, 0, 0, 0)), ".racon::createPolisher. error: invalid window length!");
 }
 
 TEST(RaconInitializeTest, SequencesPathExtensionError) {
-    EXPECT_DEATH((racon::createPolisher("", "", "", racon::PolisherType::kC, 500,
+    EXPECT_DEATH((racon::createPolisher("", "", "", "", racon::PolisherType::kC, 500,
         0, 0, 0, 0, 0, 0, 0)), ".racon::createPolisher. error: file  has unsupported "
         "format extension .valid extensions: .fasta, .fasta.gz, .fna, .fna.gz, "
         ".fa, .fa.gz, .fastq, .fastq.gz, .fq, .fq.gz.!");
@@ -72,14 +74,14 @@ TEST(RaconInitializeTest, SequencesPathExtensionError) {
 
 TEST(RaconInitializeTest, OverlapsPathExtensionError) {
     EXPECT_DEATH((racon::createPolisher(racon_test_data_path + "sample_reads.fastq.gz",
-        "", "", racon::PolisherType::kC, 500, 0, 0, 0, 0, 0, 0, 0)),
+        "", "", "", racon::PolisherType::kC, 500, 0, 0, 0, 0, 0, 0, 0)),
         ".racon::createPolisher. error: file  has unsupported format extension "
         ".valid extensions: .mhap, .mhap.gz, .paf, .paf.gz, .sam, .sam.gz.!");
 }
 
 TEST(RaconInitializeTest, TargetPathExtensionError) {
     EXPECT_DEATH((racon::createPolisher(racon_test_data_path + "sample_reads.fastq.gz",
-        racon_test_data_path + "sample_overlaps.paf.gz", "", racon::PolisherType::kC,
+        racon_test_data_path + "sample_overlaps.paf.gz", "", "", racon::PolisherType::kC,
         500, 0, 0, 0, 0, 0, 0, 0)), ".racon::createPolisher. error: file  has "
         "unsupported format extension .valid extensions: .fasta, .fasta.gz, .fna, "
         ".fna.gz, .fa, .fa.gz, .fastq, .fastq.gz, .fq, .fq.gz.!");

--- a/test/util_test.cpp
+++ b/test/util_test.cpp
@@ -16,7 +16,7 @@
 TEST(Utils, find_breaking_points_from_cigar) {
     // Tuple: test_name, CIGAR string, windows as tuples, expected breakpoints split into windows.
     std::vector<std::tuple<std::string, std::string, int64_t,
-        int64_t, std::vector<std::tuple<int64_t, int64_t, int64_t>>, std::vector<racon::WindowInterval>>> test_data = {
+        int64_t, std::vector<std::tuple<int64_t, int64_t, int64_t>>, std::vector<racon::WindowInterval>>> test_data {
         {"Empty input", "", 0, 0, {}, {}},
 
         {"Simple windowing", "1000M", 0, 0,

--- a/test/util_test.cpp
+++ b/test/util_test.cpp
@@ -1,0 +1,174 @@
+/*!
+ * @file util.cpp
+ *
+ * @brief Unit tests for the utils.
+ */
+
+#include "gtest/gtest.h"
+#include "racon_test_config.h"
+#include "util.hpp"
+
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+TEST(Utils, find_breaking_points_from_cigar) {
+    // Tuple: test_name, CIGAR string, windows as tuples, expected breakpoints split into windows.
+    std::vector<std::tuple<std::string, std::string, int64_t,
+        int64_t, std::vector<std::tuple<int64_t, int64_t, int64_t>>, std::vector<racon::WindowInterval>>> test_data = {
+        {"Empty input", "", 0, 0, {}, {}},
+
+        {"Simple windowing", "1000M", 0, 0,
+            {
+                {100, 500, 0},
+                {700, 800, 1},
+                {900, 950, 2},
+            },
+            {
+                racon::WindowInterval(100, 500, 100, 500, 0),
+                racon::WindowInterval(700, 800, 700, 800, 1),
+                racon::WindowInterval(900, 950, 900, 950, 2),
+            }
+        },
+
+        {"Simple windowing with indels", "200=100I300=50D450=", 0, 0,
+            {
+                {100, 500, 0},
+                {500, 700, 1},
+                {700, 800, 2},
+                {900, 950, 3},
+            },
+            {
+                racon::WindowInterval(100, 600, 100, 500, 0),
+                racon::WindowInterval(600, 750, 550, 700, 1),
+                racon::WindowInterval(750, 850, 700, 800, 2),
+                racon::WindowInterval(950, 1000, 900, 950, 3),
+            }
+        },
+
+        {"Intra-window alignments", "100=", 0, 250,
+            {
+                {0, 200, 0},
+                {200, 400, 1},
+                {400, 600, 2},
+                {600, 800, 3},
+                {800, 1000, 4},
+            },
+            {
+                racon::WindowInterval(0, 100, 250, 350, 1),
+            }
+        },
+
+        {"Cross-window alignments", "200=", 0, 250,
+            {
+                {0, 200, 0},
+                {200, 400, 1},
+                {400, 600, 2},
+                {600, 800, 3},
+                {800, 1000, 4},
+            },
+            {
+                racon::WindowInterval(0, 150, 250, 400, 1),
+                racon::WindowInterval(150, 200, 400, 450, 2),
+            }
+        },
+
+        {"Flanking insertions", "10I180=10I", 0, 200,
+            {
+                {0, 200, 0},
+                {200, 400, 1},
+                {400, 600, 2},
+                {600, 800, 3},
+                {800, 1000, 4},
+            },
+            {
+                racon::WindowInterval(10, 190, 200, 380, 1),
+            }
+        },
+
+        {"Flanking insertions", "10D180=10D", 0, 200,
+            {
+                {0, 200, 0},
+                {200, 400, 1},
+                {400, 600, 2},
+                {600, 800, 3},
+                {800, 1000, 4},
+            },
+            {
+                racon::WindowInterval(0, 180, 210, 390, 1),
+            }
+        },
+
+        {"Alignment outside of the windows, front", "50=", 0, 50,
+            {
+                {200, 400, 0},
+                {400, 600, 1},
+                {600, 800, 2},
+                {800, 1000, 3},
+            },
+            { }
+        },
+
+        {"Alignment outside of the windows, back", "50=", 0, 1050,
+            {
+                {200, 400, 0},
+                {400, 600, 1},
+                {600, 800, 2},
+                {800, 1000, 3},
+            },
+            { }
+        },
+
+        {"Alignment in between windows (not overlapping)", "50=", 0, 450,
+            {
+                {0, 200, 0},
+                {200, 400, 1},
+                {600, 800, 3},
+                {800, 1000, 4},
+            },
+            { }
+        },
+
+        {"Out of order windows, should still work because internal sort", "200=100I300=50D450=", 0, 0,
+            {
+                {900, 950, 3},
+                {500, 700, 1},
+                {100, 500, 0},
+                {700, 800, 2},
+            },
+            {
+                racon::WindowInterval(100, 600, 100, 500, 0),
+                racon::WindowInterval(600, 750, 550, 700, 1),
+                racon::WindowInterval(750, 850, 700, 800, 2),
+                racon::WindowInterval(950, 1000, 900, 950, 3),
+            }
+        },
+
+    };
+
+    for (const auto& single_test: test_data) {
+        const std::string& test_name = std::get<0>(single_test);
+        const std::string& cigar = std::get<1>(single_test);
+        int64_t aln_q_start = std::get<2>(single_test);
+        int64_t aln_t_start = std::get<3>(single_test);
+        const std::vector<std::tuple<int64_t, int64_t, int64_t>>& windows = std::get<4>(single_test);
+        const std::vector<racon::WindowInterval>& expected = std::get<5>(single_test);
+
+        SCOPED_TRACE(test_name);
+
+        auto result = racon::generate_window_breakpoints(cigar, aln_q_start, aln_t_start, windows);
+
+        // std::cerr << test_name << "\n";
+        // std::cerr << cigar << "\n";
+        // for (const auto& val: result) {
+        //     std::cerr << "q_start = " << val.q_start << ", q_end = " << val.q_end
+        //     << ", t_start = " << val.t_start << ", t_end = " << val.t_end
+        //     << ", window_id = " << val.window_id << "\n";
+        //     // std::cerr << val << "\n";
+        // }
+        // std::cerr << "\n";
+
+        EXPECT_EQ(expected, result);
+    }
+}

--- a/test/util_test.cpp
+++ b/test/util_test.cpp
@@ -15,135 +15,139 @@
 
 TEST(Utils, find_breaking_points_from_cigar) {
     // Tuple: test_name, CIGAR string, windows as tuples, expected breakpoints split into windows.
+    using TestTupleType = std::tuple<std::string, std::string, int64_t,
+                            int64_t, std::vector<std::tuple<int64_t, int64_t, int64_t>>,
+                            std::vector<racon::WindowInterval>>;
+    using TestWindowTuple = std::tuple<int64_t, int64_t, int64_t>;
     std::vector<std::tuple<std::string, std::string, int64_t,
-        int64_t, std::vector<std::tuple<int64_t, int64_t, int64_t>>, std::vector<racon::WindowInterval>>> test_data {
-        {"Empty input", "", 0, 0, {}, {}},
+        int64_t, std::vector<TestWindowTuple>, std::vector<racon::WindowInterval>>> test_data {
+        TestTupleType("Empty input", "", 0, 0, std::vector<TestWindowTuple>{}, std::vector<racon::WindowInterval>{}),
 
-        {"Simple windowing", "1000M", 0, 0,
-            {
-                {100, 500, 0},
-                {700, 800, 1},
-                {900, 950, 2},
+        TestTupleType("Simple windowing", "1000M", 0, 0,
+            std::vector<TestWindowTuple>{
+                TestWindowTuple{100, 500, 0},
+                TestWindowTuple{700, 800, 1},
+                TestWindowTuple{900, 950, 2},
             },
-            {
+            std::vector<racon::WindowInterval>{
                 racon::WindowInterval(100, 500, 100, 500, 0),
                 racon::WindowInterval(700, 800, 700, 800, 1),
                 racon::WindowInterval(900, 950, 900, 950, 2),
             }
-        },
+        ),
 
-        {"Simple windowing with indels", "200=100I300=50D450=", 0, 0,
-            {
-                {100, 500, 0},
-                {500, 700, 1},
-                {700, 800, 2},
-                {900, 950, 3},
+        TestTupleType("Simple windowing with indels", "200=100I300=50D450=", 0, 0,
+            std::vector<TestWindowTuple>{
+                TestWindowTuple{100, 500, 0},
+                TestWindowTuple{500, 700, 1},
+                TestWindowTuple{700, 800, 2},
+                TestWindowTuple{900, 950, 3},
             },
-            {
+            std::vector<racon::WindowInterval>{
                 racon::WindowInterval(100, 600, 100, 500, 0),
                 racon::WindowInterval(600, 750, 550, 700, 1),
                 racon::WindowInterval(750, 850, 700, 800, 2),
                 racon::WindowInterval(950, 1000, 900, 950, 3),
             }
-        },
+        ),
 
-        {"Intra-window alignments", "100=", 0, 250,
-            {
-                {0, 200, 0},
-                {200, 400, 1},
-                {400, 600, 2},
-                {600, 800, 3},
-                {800, 1000, 4},
+        TestTupleType("Intra-window alignments", "100=", 0, 250,
+            std::vector<TestWindowTuple>{
+                TestWindowTuple{0, 200, 0},
+                TestWindowTuple{200, 400, 1},
+                TestWindowTuple{400, 600, 2},
+                TestWindowTuple{600, 800, 3},
+                TestWindowTuple{800, 1000, 4},
             },
-            {
+            std::vector<racon::WindowInterval>{
                 racon::WindowInterval(0, 100, 250, 350, 1),
             }
-        },
+        ),
 
-        {"Cross-window alignments", "200=", 0, 250,
-            {
-                {0, 200, 0},
-                {200, 400, 1},
-                {400, 600, 2},
-                {600, 800, 3},
-                {800, 1000, 4},
+        TestTupleType("Cross-window alignments", "200=", 0, 250,
+            std::vector<TestWindowTuple>{
+                TestWindowTuple{0, 200, 0},
+                TestWindowTuple{200, 400, 1},
+                TestWindowTuple{400, 600, 2},
+                TestWindowTuple{600, 800, 3},
+                TestWindowTuple{800, 1000, 4},
             },
-            {
+            std::vector<racon::WindowInterval>{
                 racon::WindowInterval(0, 150, 250, 400, 1),
                 racon::WindowInterval(150, 200, 400, 450, 2),
             }
-        },
+        ),
 
-        {"Flanking insertions", "10I180=10I", 0, 200,
-            {
-                {0, 200, 0},
-                {200, 400, 1},
-                {400, 600, 2},
-                {600, 800, 3},
-                {800, 1000, 4},
+        TestTupleType("Flanking insertions", "10I180=10I", 0, 200,
+            std::vector<TestWindowTuple>{
+                TestWindowTuple{0, 200, 0},
+                TestWindowTuple{200, 400, 1},
+                TestWindowTuple{400, 600, 2},
+                TestWindowTuple{600, 800, 3},
+                TestWindowTuple{800, 1000, 4},
             },
-            {
+            std::vector<racon::WindowInterval>{
                 racon::WindowInterval(10, 190, 200, 380, 1),
             }
-        },
+        ),
 
-        {"Flanking insertions", "10D180=10D", 0, 200,
-            {
-                {0, 200, 0},
-                {200, 400, 1},
-                {400, 600, 2},
-                {600, 800, 3},
-                {800, 1000, 4},
+        TestTupleType("Flanking insertions", "10D180=10D", 0, 200,
+            std::vector<TestWindowTuple>{
+                TestWindowTuple{0, 200, 0},
+                TestWindowTuple{200, 400, 1},
+                TestWindowTuple{400, 600, 2},
+                TestWindowTuple{600, 800, 3},
+                TestWindowTuple{800, 1000, 4},
             },
-            {
+            std::vector<racon::WindowInterval>{
                 racon::WindowInterval(0, 180, 210, 390, 1),
             }
-        },
+        ),
 
-        {"Alignment outside of the windows, front", "50=", 0, 50,
-            {
-                {200, 400, 0},
-                {400, 600, 1},
-                {600, 800, 2},
-                {800, 1000, 3},
+        TestTupleType("Alignment outside of the windows, front", "50=", 0, 50,
+            std::vector<TestWindowTuple>{
+                TestWindowTuple{200, 400, 0},
+                TestWindowTuple{400, 600, 1},
+                TestWindowTuple{600, 800, 2},
+                TestWindowTuple{800, 1000, 3},
             },
-            { }
-        },
+            std::vector<racon::WindowInterval>{ }
+        ),
 
-        {"Alignment outside of the windows, back", "50=", 0, 1050,
-            {
-                {200, 400, 0},
-                {400, 600, 1},
-                {600, 800, 2},
-                {800, 1000, 3},
+        TestTupleType("Alignment outside of the windows, back", "50=", 0, 1050,
+            std::vector<TestWindowTuple>{
+                TestWindowTuple{200, 400, 0},
+                TestWindowTuple{400, 600, 1},
+                TestWindowTuple{600, 800, 2},
+                TestWindowTuple{800, 1000, 3},
             },
-            { }
-        },
+            std::vector<racon::WindowInterval>{ }
+        ),
 
-        {"Alignment in between windows (not overlapping)", "50=", 0, 450,
-            {
-                {0, 200, 0},
-                {200, 400, 1},
-                {600, 800, 3},
-                {800, 1000, 4},
+        TestTupleType("Alignment in between windows (not overlapping)", "50=", 0, 450,
+            std::vector<TestWindowTuple>{
+                TestWindowTuple{0, 200, 0},
+                TestWindowTuple{200, 400, 1},
+                TestWindowTuple{600, 800, 3},
+                TestWindowTuple{800, 1000, 4},
             },
-            { }
-        },
+            std::vector<racon::WindowInterval>{ }
+        ),
 
-        {"Out of order windows, should still work because internal sort", "200=100I300=50D450=", 0, 0,
-            {
-                {900, 950, 3},
-                {500, 700, 1},
-                {100, 500, 0},
-                {700, 800, 2},
+        TestTupleType("Out of order windows, should still work because internal sort", "200=100I300=50D450=", 0, 0,
+            std::vector<TestWindowTuple>{
+                TestWindowTuple{900, 950, 3},
+                TestWindowTuple{500, 700, 1},
+                TestWindowTuple{100, 500, 0},
+                TestWindowTuple{700, 800, 2},
             },
-            {
+            std::vector<racon::WindowInterval>{
                 racon::WindowInterval(100, 600, 100, 500, 0),
                 racon::WindowInterval(600, 750, 550, 700, 1),
                 racon::WindowInterval(750, 850, 700, 800, 2),
                 racon::WindowInterval(950, 1000, 900, 950, 3),
             }
-        },
+        ),
 
     };
 

--- a/vendor/meson.build
+++ b/vendor/meson.build
@@ -1,5 +1,6 @@
 vendor_cpp_sources = files([
   'edlib/edlib/src/edlib.cpp',
+  'intervaltree/interval_tree_test.cpp',
   'rampler/src/sampler.cpp',
   'rampler/src/sequence.cpp',
   'spoa/src/alignment_engine.cpp',
@@ -7,15 +8,16 @@ vendor_cpp_sources = files([
   'spoa/src/sequence.cpp',
   'spoa/src/simd_alignment_engine.cpp',
   'spoa/src/sisd_alignment_engine.cpp',
-  'thread_pool/src/thread_pool.cpp'
+  'thread_pool/src/thread_pool.cpp',
 ])
 
 vendor_include_directories = [
                 include_directories('bioparser/include'),
                 include_directories('edlib/edlib/include'),
+                include_directories('intervaltree/'),
                 include_directories('rampler/src'),
                 include_directories('spoa/include'),
-                include_directories('thread_pool/include')
+                include_directories('thread_pool/include'),
                 ]
 
 vendor_extra_flags = []

--- a/vendor/meson.build
+++ b/vendor/meson.build
@@ -1,6 +1,5 @@
 vendor_cpp_sources = files([
   'edlib/edlib/src/edlib.cpp',
-  'intervaltree/interval_tree_test.cpp',
   'rampler/src/sampler.cpp',
   'rampler/src/sequence.cpp',
   'spoa/src/alignment_engine.cpp',


### PR DESCRIPTION
This PR adds a BED feature to polish only the specified regions of the input draft.
The feature is very useful when an assembly was patched (for example manually or by scaffolding), and the user wants to target only those regions instead of potentially disrupting an already high quality assembly.

One could suggest that instead of this feature the user should simply filter and clip overlaps from the outside, but that has a very nasty side-effect: since the region can begin at an arbitrary position (e.g. 1237bp in target), and the current windowing splits windows in fixed intervals (e.g. 500bp), that would mean that the first 237bp of the window where the region begins would have coverage 0x and the heuristics would kick in to trim the window. The end result would be a severely deteriorated assembly.
Another argument might be to turn off window trimming, but then internal windows would have plenty of insertions at their ends.

The only way around this is to implement a proper region-based polishing which generalizes to the full contig size as well as specified regions.

To implement this, some refactoring had to be done. Here is a brief description of work:
- The way breaking points were constructed had to be refactored because it was rigid (it expected that the polishing begins at coordinate 0 and would split the CIGAR in equally distant target coordinates), and entangled (it is not the responsibility of the Overlap class to find the CIGAR breakpoints).
- The Window class now stores both the start and end target coordinate of a window, which is very important to allow an arbitrary start/stop region for polishing. This feature will also be very useful in an unrelated upcoming feature.
- I added unit tests to verify that the breakpoint construction is good. Previously, this was untested, and there was a bug in the old logic. The new version seems to work properly.
- Added the BED parser, and unit tests to cover the code.

Both the regions and the windows may be of an arbitrary size.