### PR TITLE
Spoa upgrade

### DIFF
--- a/.github/workflows/racon.yml
+++ b/.github/workflows/racon.yml
@@ -10,40 +10,36 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         image:
           - gcc:7
           - silkeh/clang:7
         build_type:
-          - Debug, Release
+          - Debug
+          - Release
     container:
       image: ${{ matrix.image }}
       options: --user root
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Install build dependencies
         run: |
           chmod +x ci/install_deps.sh
           ./ci/install_deps.sh
 
-      - name: Create build directory
-        run: cmake -E make_directory build
 
       - name: Generate build files
-        working-directory: build
         run: >
-          cmake ..
-          -G Ninja
+          cmake -B ./build -G Ninja
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
       - name: Build
-        working-directory: build
-        run: cmake --build .
+        run: cmake --build ./build
 
       - name: Test
-        working-directory: build
         run: |
-          bin/racon --version
-          bin/racon_test
+          ./build/bin/racon --version
+          ./build/bin/racon_test

--- a/.github/workflows/racon.yml
+++ b/.github/workflows/racon.yml
@@ -6,48 +6,44 @@ on:
     branches:
       - master
 
-env:
-  BUILD_TYPE: Release
-
 jobs:
   test:
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        compiler:
-          - g++
-          - g++-4.8
-          - clang++
-          - clang++-4.0
-
-    runs-on: ubuntu-18.04
+        image:
+          - gcc:7
+          - silkeh/clang:7
+        build_type:
+          - Debug, Release
+    container:
+      image: ${{ matrix.image }}
+      options: --user root
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          chmod +x ci/install_deps.sh
+          ./ci/install_deps.sh
 
-      - if: ${{ matrix.compiler == 'g++-4.8' }}
-        name: Setup GCC
-        uses: egor-tensin/setup-gcc@v1
-        with:
-          version: "4.8"
-          platform: x64
+      - name: Create build directory
+        run: cmake -E make_directory build
 
-      - if: ${{ matrix.compiler == 'clang++-4.0' }}
-        name: Setup Clang
-        uses: egor-tensin/setup-clang@v1
-        with:
-          version: "4.0"
-          platform: x64
-
-      - name: Configure CMake
-        run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
-        env:
-          CXX: ${{ matrix.compiler }}
+      - name: Generate build files
+        working-directory: build
+        run: >
+          cmake ..
+          -G Ninja
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
       - name: Build
-        run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }}
+        working-directory: build
+        run: cmake --build .
 
       - name: Test
-        working-directory: ${{ github.workspace }}/build
+        working-directory: build
         run: |
           bin/racon --version
           bin/racon_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.12)
 
 project(racon VERSION 1.5.0
               LANGUAGES CXX
               DESCRIPTION "Racon is a consensus module for de novo genome assembly.")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -57,12 +57,12 @@ if (NOT edlib_FOUND)
   endif ()
 endif ()
 
-find_package(spoa 4.0.8 QUIET)
+find_package(spoa 4.1.2 QUIET)
 if (NOT spoa_FOUND)
   FetchContent_Declare(
     spoa
     GIT_REPOSITORY https://github.com/rvaser/spoa
-    GIT_TAG 4.0.8)
+    GIT_TAG 4.1.2)
 
   FetchContent_GetProperties(spoa)
   if (NOT spoa_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 project(racon VERSION 1.5.0
               LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if (NOT spoa_FOUND)
   FetchContent_Declare(
     spoa
     GIT_REPOSITORY https://github.com/rvaser/spoa
-    GIT_TAG 4.1.2)
+    GIT_TAG fd3a5c58c1acbdf649ec956acb7dca5f24638f72)
 
   FetchContent_GetProperties(spoa)
   if (NOT spoa_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if (NOT edlib_FOUND)
   endif ()
 endif ()
 
-find_package(spoa 4.1.2 QUIET)
+find_package(spoa 4.1.4 QUIET)
 if (NOT spoa_FOUND)
   FetchContent_Declare(
     spoa

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Racon can also be used as a read error-correction tool. In this scenario, the MH
 A **wrapper script** is also available to enable easier usage to the end-user for large datasets. It has the same interface as racon but adds two additional features from the outside. Sequences can be **subsampled** to decrease the total execution time (accuracy might be lower) while target sequences can be **split** into smaller chunks and run sequentially to decrease memory consumption. Both features can be run at the same time as well.
 
 ## Dependencies
-1. gcc 4.8+ or clang 3.4+
-2. cmake 3.2+
+1. gcc 7+ or clang 7+
+2. cmake 3.12+
 3. zlib
 
 ### CUDA Support
-1. gcc 5.0+
-2. cmake 3.10+
+1. gcc 7+
+2. cmake 3.12+
 3. CUDA 9.0+
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Usage of `racon` is as following:
             maximum allowed error rate used for filtering overlaps
         --no-trimming
             disables consensus trimming at window ends
+        --min-coverage <int>
+            default: -1
+            minimal consensus coverage
         -m, --match <int>
             default: 3
             score for matching bases

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -3,11 +3,11 @@ set -eou pipefail
 
 apt update && apt install -y git zlib1g-dev curl ninja-build
 
-VERSION="3.13.4"
+VERSION="3.16.5"
 MIRROR_URL="https://github.com/Kitware/CMake/releases/download/v$VERSION"
 DOWNLOAD="cmake-$VERSION-linux-x86_64.sh"
 DOWNLOAD_FILE="/tmp/cmake.sh"
 
 curl -Ls "${MIRROR_URL}/${DOWNLOAD}" --output "${DOWNLOAD_FILE}"
 bash "${DOWNLOAD_FILE}" --skip-license --prefix=/usr/local --exclude-subdir
-which cmake
+cmake --version

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+apt update && apt install -y git zlib1g-dev curl ninja-build
+
+VERSION="3.13.4"
+MIRROR_URL="https://github.com/Kitware/CMake/releases/download/v$VERSION"
+DOWNLOAD="cmake-$VERSION-linux-x86_64.sh"
+DOWNLOAD_FILE="/tmp/cmake.sh"
+
+curl -Ls "${MIRROR_URL}/${DOWNLOAD}" --output "${DOWNLOAD_FILE}"
+bash "${DOWNLOAD_FILE}" --skip-license --prefix=/usr/local --exclude-subdir
+which cmake

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
   default_options : [
     'buildtype=release',
     'warning_level=3',
-    'cpp_std=c++11'],
+    'cpp_std=c++17'],
   license : 'MIT',
   meson_version : '>= 0.50.0')
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@ static struct option options[] = {
     {"quality-threshold", required_argument, 0, 'q'},
     {"error-threshold", required_argument, 0, 'e'},
     {"no-trimming", no_argument, 0, 'T'},
+    {"min-coverage", required_argument, nullptr, 'M'},
     {"match", required_argument, 0, 'm'},
     {"mismatch", required_argument, 0, 'x'},
     {"gap", required_argument, 0, 'g'},
@@ -48,6 +49,7 @@ int main(int argc, char** argv) {
     double error_threshold = 0.3;
     bool trim = true;
 
+    int32_t min_coverage = -1;
     int8_t match = 3;
     int8_t mismatch = -5;
     int8_t gap = -4;
@@ -86,6 +88,9 @@ int main(int argc, char** argv) {
                 break;
             case 'T':
                 trim = false;
+                break;
+            case 'M':
+                min_coverage = atoi(optarg);
                 break;
             case 'm':
                 match = atoi(optarg);
@@ -147,7 +152,7 @@ int main(int argc, char** argv) {
     auto polisher = racon::createPolisher(input_paths[0], input_paths[1],
         input_paths[2], type == 0 ? racon::PolisherType::kC :
         racon::PolisherType::kF, window_length, quality_threshold,
-        error_threshold, trim, match, mismatch, gap, num_threads,
+        error_threshold, trim, min_coverage, match, mismatch, gap, num_threads,
         cudapoa_batches, cuda_banded_alignment, cudaaligner_batches,
         cudaaligner_band_width);
 
@@ -195,6 +200,9 @@ void help() {
         "            maximum allowed error rate used for filtering overlaps\n"
         "        --no-trimming\n"
         "            disables consensus trimming at window ends\n"
+        "        --min-coverage <int>\n"
+        "            default: -1\n"
+        "            minimal consensus coverage\n"
         "        -m, --match <int>\n"
         "            default: 3\n"
         "            score for matching bases\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,7 +152,7 @@ int main(int argc, char** argv) {
     auto polisher = racon::createPolisher(input_paths[0], input_paths[1],
         input_paths[2], type == 0 ? racon::PolisherType::kC :
         racon::PolisherType::kF, window_length, quality_threshold,
-        error_threshold, trim, min_coverage, match, mismatch, gap, num_threads,
+        error_threshold, trim, match, mismatch, gap, num_threads, min_coverage,
         cudapoa_batches, cuda_banded_alignment, cudaaligner_batches,
         cudaaligner_band_width);
 

--- a/src/polisher.cpp
+++ b/src/polisher.cpp
@@ -57,10 +57,10 @@ void shrinkToFit(std::vector<std::unique_ptr<T>>& src, uint64_t begin) {
 std::unique_ptr<Polisher> createPolisher(const std::string& sequences_path,
     const std::string& overlaps_path, const std::string& target_path,
     PolisherType type, uint32_t window_length, double quality_threshold,
-    double error_threshold, bool trim, int8_t match, int8_t mismatch, int8_t gap,
-    uint32_t num_threads, int32_t min_coverage, uint32_t cudapoa_batches,
-    bool cuda_banded_alignment, uint32_t cudaaligner_batches,
-    uint32_t cudaaligner_band_width) {
+    double error_threshold, bool trim, int8_t match, int8_t mismatch,
+    int8_t gap, uint32_t num_threads, int32_t min_coverage,
+    uint32_t cudapoa_batches, bool cuda_banded_alignment,
+    uint32_t cudaaligner_batches, uint32_t cudaaligner_band_width) {
 
     if (type != PolisherType::kC && type != PolisherType::kF) {
         fprintf(stderr, "[racon::createPolisher] error: invalid polisher type!\n");

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -44,7 +44,7 @@ std::unique_ptr<Polisher> createPolisher(const std::string& sequences_path,
     const std::string& overlaps_path, const std::string& target_path,
     PolisherType type, uint32_t window_length, double quality_threshold,
     double error_threshold, bool trim, int8_t match, int8_t mismatch, int8_t gap,
-    uint32_t num_threads, uint32_t cuda_batches = 0,
+    uint32_t num_threads, int32_t min_coverage = -1, uint32_t cuda_batches = 0,
     bool cuda_banded_alignment = false, uint32_t cudaaligner_batches = 0,
     uint32_t cudaaligner_band_width = 0);
 
@@ -61,8 +61,9 @@ public:
         const std::string& overlaps_path, const std::string& target_path,
         PolisherType type, uint32_t window_length, double quality_threshold,
         double error_threshold, bool trim, int8_t match, int8_t mismatch, int8_t gap,
-        uint32_t num_threads, uint32_t cuda_batches, bool cuda_banded_alignment,
-        uint32_t cudaaligner_batches, uint32_t cudaaligner_band_width);
+        uint32_t num_threads, int32_t min_coverage, uint32_t cuda_batches,
+        bool cuda_banded_alignment, uint32_t cudaaligner_batches,
+        uint32_t cudaaligner_band_width);
 
 protected:
     Polisher(std::unique_ptr<bioparser::Parser<Sequence>> sparser,
@@ -70,7 +71,7 @@ protected:
         std::unique_ptr<bioparser::Parser<Sequence>> tparser,
         PolisherType type, uint32_t window_length, double quality_threshold,
         double error_threshold, bool trim, int8_t match, int8_t mismatch, int8_t gap,
-        uint32_t num_threads);
+        uint32_t num_threads, int32_t min_coverage);
     Polisher(const Polisher&) = delete;
     const Polisher& operator=(const Polisher&) = delete;
     virtual void find_overlap_breaking_points(std::vector<std::unique_ptr<Overlap>>& overlaps);
@@ -83,6 +84,7 @@ protected:
     double quality_threshold_;
     double error_threshold_;
     bool trim_;
+    int32_t min_coverage_;
     std::vector<std::shared_ptr<spoa::AlignmentEngine>> alignment_engines_;
 
     std::vector<std::unique_ptr<Sequence>> sequences_;

--- a/src/polisher.hpp
+++ b/src/polisher.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <unordered_map>
 #include <thread>
+#include <string>
 
 namespace bioparser {
     template<class T>

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -63,7 +63,7 @@ void Window::add_layer(const char* sequence, uint32_t sequence_length,
 }
 
 bool Window::generate_consensus(std::shared_ptr<spoa::AlignmentEngine> alignment_engine,
-    bool trim) {
+    bool trim, int32_t min_coverage) {
 
     if (sequences_.size() < 3) {
         consensus_ = std::string(sequences_.front().first, sequences_.front().second);
@@ -120,7 +120,7 @@ bool Window::generate_consensus(std::shared_ptr<spoa::AlignmentEngine> alignment
     }
 
     std::vector<uint32_t> coverages;
-    consensus_ = graph.GenerateConsensus(&coverages);
+    consensus_ = graph.GenerateConsensus(&coverages, min_coverage);
 
     if (type_ == WindowType::kTGS && trim) {
         uint32_t average_coverage = (sequences_.size() - 1) / 2;

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -45,7 +45,7 @@ public:
     }
 
     bool generate_consensus(std::shared_ptr<spoa::AlignmentEngine> alignment_engine,
-        bool trim);
+        bool trim, int32_t min_coverage);
 
     void add_layer(const char* sequence, uint32_t sequence_length,
         const char* quality, uint32_t quality_length, uint32_t begin,


### PR DESCRIPTION
# Descriptions

The aim of this PR is to improve racon performance with the new SPOA version which takes into a count node coverage when calculating the consensus. For more information see:

- [SPOA coverage threshold option commit](https://github.com/rvaser/spoa/commit/08957f6b87ce4262358a88c6b2c3c7860cf60239)

## Tasks

- [x] upgrade to c++17 to allow support for newer SPOA versions
  - [x] upgrade CMake
  - [x] upgrade meson
  - [ ] upgrade ci scripts

- [ ] upgrade SPOA version
  - [x] CMake
  - [ ] git submodules for meson

- [x] utilize `min_coverage`
  - [x] add command line argument
  - [x] add `min_coverage` parameter to polisher and use it for consensus generation
  
  ## Results
- TODO